### PR TITLE
Lexicographic Orderings

### DIFF
--- a/src/1Lab/Data/List.lagda.md
+++ b/src/1Lab/Data/List.lagda.md
@@ -12,6 +12,14 @@ module 1Lab.Data.List where
 A _list_ is a finite, ordered sequence of elements of some type. Lists
 are an inductive type:
 
+<!--
+```
+private variable
+  ℓ : Level
+  A : Type ℓ
+```
+-->
+
 ```agda
 data List {ℓ} (A : Type ℓ) : Type ℓ where
   nil : List A
@@ -48,6 +56,7 @@ isSet→List-isSet {A = A} set = Rijke-isSet {R = R} R-refl R-impliesId R-isProp
 We can define concatenation of lists by recursion:
 
 ```agda
+infixr 5 _++_
 _++_ : ∀ {ℓ} {A : Type ℓ} → List A → List A → List A
 nil      ++ ys = ys
 (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
@@ -68,4 +77,45 @@ both left and right units:
 ++-idʳ : ∀ {ℓ} {A : Type ℓ} (xs : List A) → xs ++ nil ≡ xs
 ++-idʳ nil i = nil
 ++-idʳ (x ∷ xs) i = x ∷ ++-idʳ xs i
+```
+
+## Lemmas
+
+Now, for a bunch of useful little lemmas! First, `∷` is injective
+in both arguments:
+
+```agda
+head : A → List A → A
+head def nil     = def
+head _   (x ∷ _) = x
+
+tail : List A → List A
+tail nil      = nil
+tail (_ ∷ xs) = xs
+
+∷-head-inj : ∀ {x y : A} {xs ys} → (x ∷ xs) ≡ (y ∷ ys) → x ≡ y
+∷-head-inj {x = x} p = ap (head x) p
+
+∷-tail-inj : ∀ {x y : A} {xs ys} → (x ∷ xs) ≡ (y ∷ ys) → xs ≡ ys
+∷-tail-inj p = ap tail p
+```
+
+Continuing with the useful lemmas, if the head and tail of two lists are equal,
+then the two lists are equal:
+
+```agda
+ap-∷ : ∀ {x y : A} {xs ys} → x ≡ y → xs ≡ ys → x ∷ xs ≡ y ∷ ys
+ap-∷ {x = x} {y = y} {xs = xs} {ys = ys} x≡y xs≡ys =
+  subst (λ z → x ∷ xs ≡ z ∷ ys) x≡y (ap (x ∷_) xs≡ys)
+```
+
+It is impossible for an empty list to be equal to a non-empty one:
+
+```agda
+∷≠nil : ∀ {x : A} {xs} → (x ∷ xs) ≡ nil → ⊥
+∷≠nil {A = A} p = subst distinguish p tt
+  where
+    distinguish : List A → Type
+    distinguish nil     = ⊥
+    distinguish (_ ∷ _) = ⊤
 ```

--- a/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
+++ b/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
@@ -1,0 +1,95 @@
+```agda
+open import 1Lab.Type
+open import 1Lab.Path
+
+open import 1Lab.Data.List
+open import 1Lab.Data.Relation.Order
+
+module 1Lab.Data.Relation.Order.Lexicographic where
+```
+
+# Lexicographic Orderings
+
+A **Lexicographic Orderings** can be thought of as a generalization of how we sort words.
+For instance, if we were to look up "math" in the dictionary, it would come
+before "mathematician", but after "cube". By generalizing the order in question,
+we can get a notion of ordering for any arbitrary list, instead of just lists of characters.
+
+We define our ordering as an inductive type:
+
+```agda
+data Lex {ℓ ℓ'} {A : Type ℓ}
+         (_≺_ : A → A → Type ℓ') : List A → List A → Type (ℓ ⊔ ℓ') where
+  done     : ∀ {y ys}                      → Lex _≺_ nil      (y ∷ ys)
+  here     : ∀ {x xs y ys} → x ≺ y         → Lex _≺_ (x ∷ xs) (y ∷ ys)
+  next     : ∀ {x xs ys}   → Lex _≺_ xs ys → Lex _≺_ (x ∷ xs) (x ∷ ys)
+```
+
+
+<!--
+```agda
+private
+  variable
+    ℓ ℓ'  : Level
+    A     : Type ℓ
+    _≺_   : A → A → Type ℓ'
+    x y   : A
+    xs ys : List A
+```
+-->
+
+## Lemmas
+
+In order to prove further results, we are going to need a handful of little lemmas.
+First, let's show that if the head `xs` is greater than the head of `ys`, then
+then `xs` cannot be smaller than `ys`:
+
+```agda
+lex-antisym-head : (x ≺ y → ⊥) → (x ≡ y → ⊥) → Lex _≺_ (x ∷ xs) (y ∷ ys) → ⊥
+lex-antisym-head ¬x≺y ¬x≡y (here x≺y) = ¬x≺y x≺y
+lex-antisym-head ¬x≺y ¬x≡y (next _)   = ¬x≡y refl
+```
+
+We can show something similar for the tails of lists as well!
+
+```agda
+lex-antisym-tail : (x ≺ y → ⊥) → (Lex _≺_ xs ys → ⊥) → Lex _≺_ (x ∷ xs) (y ∷ ys) → ⊥
+lex-antisym-tail ¬x≺y ¬xs≺ys (here x≺y)   = ¬x≺y x≺y
+lex-antisym-tail ¬x≺y ¬xs≺ys (next xs≺ys) = ¬xs≺ys xs≺ys
+```
+
+When we defined `next`, we specified it's type as `Lex _≺_ (x ∷ xs) (x ∷ ys)`.
+We could have given it the type `Lex _≺_ (x ∷ xs) (y ∷ ys)` and required a proof
+that `x ≡ y`, but that would mean a lot more `substs` when we go to use it.
+
+However, it does mean that we need to prove the following lemma:
+
+```agda
+ap-∷-next : x ≡ y → Lex _≺_ xs ys → Lex _≺_ (x ∷ xs) (y ∷ ys)
+ap-∷-next {x = x} {xs = xs} {ys = ys} x≡y xs≺ys =
+  subst (λ z → Lex _ (x ∷ xs) (z ∷ ys)) x≡y (next xs≺ys)
+```
+
+## Trichotomy
+
+Note that we have provided a _non-strict_ version! This means the relation
+is irreflexive rather than reflexive. There's a good reason for doing so:
+it makes the relation trichotomous.
+
+```agda
+lex-trichotomous : isTrichotomous _≺_ → isTrichotomous (Lex _≺_)
+lex-trichotomous tri nil      nil      = eq (λ ()) refl (λ ())
+lex-trichotomous tri nil      (x ∷ ys) = lt done (∷≠nil ∘ sym) (λ ())
+lex-trichotomous tri (x ∷ xs) nil      = gt (λ ()) ∷≠nil done
+lex-trichotomous tri (x ∷ xs) (y ∷ ys) with tri x y | lex-trichotomous tri xs ys
+... | lt  x≺y ¬x≡y ¬y≺x | _ =
+  lt (here x≺y) (¬x≡y ∘ ∷-head-inj) (lex-antisym-head ¬y≺x (¬x≡y ∘ sym))
+... | gt ¬x≺y ¬x≡y  y≺x | _ =
+  gt (lex-antisym-head ¬x≺y ¬x≡y) (¬x≡y ∘ ∷-head-inj) (here y≺x)
+... | eq _     x≡y ¬y≺x | lt xs≺ys ¬xs≡ys ¬ys≺xs =
+  lt (ap-∷-next x≡y xs≺ys) (¬xs≡ys ∘ ∷-tail-inj) (lex-antisym-tail ¬y≺x ¬ys≺xs)
+... | eq ¬x≺y x≡y ¬y≺x  | eq ¬xs≺ys xs≡ys ¬ys≺xs =
+  eq (lex-antisym-tail ¬x≺y ¬xs≺ys) (ap-∷ x≡y xs≡ys) (lex-antisym-tail ¬y≺x ¬ys≺xs)
+... | eq ¬x≺y x≡y ¬y≺x  | gt ¬xs≺ys ¬xs≡ys ys≺xs =
+  gt (lex-antisym-tail ¬x≺y ¬xs≺ys) (¬xs≡ys ∘ ∷-tail-inj) (ap-∷-next (sym x≡y) ys≺xs)
+```

--- a/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
+++ b/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
@@ -76,6 +76,11 @@ Note that we have provided a _non-strict_ version! This means the relation
 is irreflexive rather than reflexive. There's a good reason for doing so:
 it makes the relation trichotomous.
 
+This proof is a bit of a monster, so don't feel bad if it's
+overwhelming! The core idea is that we can walk down both lists,
+comparing each element as we go. Most of the code here is
+simply to convince Agda that various situations are impossible.
+
 ```agda
 lex-trichotomous : isTrichotomous _≺_ → isTrichotomous (Lex _≺_)
 lex-trichotomous tri nil      nil      = eq (λ ()) refl (λ ())

--- a/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
+++ b/src/1Lab/Data/Relation/Order/Lexicographic.lagda.md
@@ -10,7 +10,7 @@ module 1Lab.Data.Relation.Order.Lexicographic where
 
 # Lexicographic Orderings
 
-A **Lexicographic Orderings** can be thought of as a generalization of how we sort words.
+A **Lexicographic Ordering** can be thought of as a generalization of how we sort words.
 For instance, if we were to look up "math" in the dictionary, it would come
 before "mathematician", but after "cube". By generalizing the order in question,
 we can get a notion of ordering for any arbitrary list, instead of just lists of characters.


### PR DESCRIPTION
# Description

This PR adds (non-strict) lexicographic orderings. These are required for #1.

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.