### PR TITLE
Exponentials and order

### DIFF
--- a/src/1Lab/Data/Nat.lagda.md
+++ b/src/1Lab/Data/Nat.lagda.md
@@ -105,6 +105,61 @@ self-explanatory:
   y * z + x * (y * z) ∎
 ```
 
+The exponentiation operator `^`{.Agda} is defined by recursion on the
+exponent and satisfies its typical properties:
+
+```agda
+_^_ : Nat → Nat → Nat
+x ^ zero = 1
+x ^ suc y = x * (x ^ y)
+
+infixr 8 _^_
+
+^-oneʳ : (x : Nat) → x ^ 1 ≡ x
+^-oneʳ x = *-oneʳ x
+
+^-oneˡ : (x : Nat) → 1 ^ x ≡ 1
+^-oneˡ zero = refl
+^-oneˡ (suc x) =
+  (1 ^ x) + 0 ≡⟨ +-zeroʳ (1 ^ x) ⟩
+  (1 ^ x)     ≡⟨ ^-oneˡ x ⟩
+  1 ∎
+
+^-+-hom-*ʳ : (x y z : Nat) → x ^ (y + z) ≡ (x ^ y) * (x ^ z)
+^-+-hom-*ʳ x zero z = sym (+-zeroʳ (x ^ z))
+^-+-hom-*ʳ x (suc y) z =
+  x * x ^ (y + z)     ≡⟨ ap (x *_) (^-+-hom-*ʳ x y z) ⟩
+  x * (x ^ y * x ^ z) ≡⟨ sym (*-associative x (x ^ y) (x ^ z)) ⟩
+  x * x ^ y * x ^ z ∎
+
+^-distrib-*ʳ : (x y z : Nat) → (x * y) ^ z ≡ x ^ z * y ^ z
+^-distrib-*ʳ x y zero = refl
+^-distrib-*ʳ x y (suc z) = 
+  x * y * (x * y) ^ z     ≡⟨ ap (λ a → x * y * a) (^-distrib-*ʳ x y z) ⟩
+  x * y * (x ^ z * y ^ z) ≡⟨ sym (*-associative (x * y) (x ^ z) (y ^ z)) ⟩
+  x * y * x ^ z * y ^ z   ≡⟨ ap (_* y ^ z) (*-associative x y (x ^ z)) ⟩
+  x * (y * x ^ z) * y ^ z ≡⟨ ap (λ a → x * a * y ^ z) (*-commutative y (x ^ z)) ⟩
+  x * (x ^ z * y) * y ^ z ≡⟨ ap (_* y ^ z) (sym (*-associative x (x ^ z) y)) ⟩
+  x * x ^ z * y * y ^ z   ≡⟨ *-associative (x * x ^ z) y (y ^ z) ⟩
+  x * x ^ z * (y * y ^ z) ∎
+
+^-*-adjunct : (x y z : Nat) → (x ^ y) ^ z ≡ x ^ (y * z)
+^-*-adjunct x zero z = ^-oneˡ z
+^-*-adjunct x (suc y) zero = ^-*-adjunct x y zero
+^-*-adjunct x (suc y) (suc z) =
+  x * x ^ y * (x * x ^ y) ^ z       ≡⟨ ap (λ a → x * x ^ y * a) (^-distrib-*ʳ x (x ^ y) z) ⟩
+  x * x ^ y * (x ^ z * (x ^ y) ^ z) ≡⟨ ap (λ a → x * x ^ y * (x ^ z * a)) (^-*-adjunct x y z) ⟩
+  x * x ^ y * (x ^ z * x ^ (y * z)) ≡⟨ ap (λ a → x * x ^ y * a) (sym (^-+-hom-*ʳ x z (y * z))) ⟩
+  x * x ^ y * (x ^ (z + (y * z)))   ≡⟨ *-associative x (x ^ y) (x ^ (z + y * z)) ⟩
+  x * (x ^ y * (x ^ (z + (y * z)))) ≡⟨ ap (x *_) (sym (^-+-hom-*ʳ x y (z + y * z))) ⟩
+  x * x ^ (y + (z + y * z))         ≡⟨ ap (λ a → x * x ^ a) (sym (+-associative y z (y * z))) ⟩
+  x * x ^ (y + z + y * z)           ≡⟨ ap (λ a → x * x ^ (a + y * z)) (+-commutative y z) ⟩
+  x * x ^ (z + y + y * z)           ≡⟨ ap (λ a → x * x ^ a) (+-associative z y (y * z)) ⟩
+  x * x ^ (z + (y + y * z))         ≡⟨ ap (λ a → x * x ^ (z + a)) (sym (*-sucʳ y z))  ⟩
+  x * x ^ (z + y * suc z) ∎
+```
+
+
 ## Discreteness
 
 A more interesting property of the natural numbers is that they are

--- a/src/1Lab/Data/Nat.lagda.md
+++ b/src/1Lab/Data/Nat.lagda.md
@@ -134,7 +134,7 @@ infixr 8 _^_
 
 ^-distrib-*ʳ : (x y z : Nat) → (x * y) ^ z ≡ x ^ z * y ^ z
 ^-distrib-*ʳ x y zero = refl
-^-distrib-*ʳ x y (suc z) = 
+^-distrib-*ʳ x y (suc z) =
   x * y * (x * y) ^ z     ≡⟨ ap (λ a → x * y * a) (^-distrib-*ʳ x y z) ⟩
   x * y * (x ^ z * y ^ z) ≡⟨ sym (*-associative (x * y) (x ^ z) (y ^ z)) ⟩
   x * y * x ^ z * y ^ z   ≡⟨ ap (_* y ^ z) (*-associative x y (x ^ z)) ⟩
@@ -208,6 +208,7 @@ zero ≤ zero = ⊤
 zero ≤ suc y = ⊤
 suc x ≤ zero = ⊥
 suc x ≤ suc y = x ≤ y
+infix 3 _≤_
 ```
 
 Then we can prove it is reflexive, transitive and antisymmetric, making
@@ -261,4 +262,40 @@ Furthermore, ≤ is decidable:
 ≤-dec zero (suc y) = yes tt
 ≤-dec (suc x) zero = no (λ z → z)
 ≤-dec (suc x) (suc y) = ≤-dec x y
+```
+
+It is also preserved by the main arithmetical operations:
+
+```agda
++-preserves-≤ˡ : (x y z : Nat) → x ≤ y → z + x ≤ z + y
++-preserves-≤ˡ x y zero prf = prf
++-preserves-≤ˡ x y (suc z) prf = +-preserves-≤ˡ x y z prf
+
++-preserves-≤ʳ : (x y z : Nat) → x ≤ y → x + z ≤ y + z
++-preserves-≤ʳ x y z prf = subst (λ a → a ≤ y + z) (+-commutative z x)
+  (subst (λ a → z + x ≤ a) (+-commutative z y) (+-preserves-≤ˡ x y z prf))
+
++-preserves-≤ : (x y x' y' : Nat) → x ≤ y → x' ≤ y' → x + x' ≤ y + y'
++-preserves-≤ x y x' y' prf prf' = ≤-trans (x + x') (y + x') (y + y')
+  (+-preserves-≤ʳ x y x' prf) (+-preserves-≤ˡ x' y' y prf')
+
+*-preserves-≤ˡ : (x y z : Nat) → x ≤ y → z * x ≤ z * y
+*-preserves-≤ˡ x y zero prf = tt
+*-preserves-≤ˡ x y (suc z) prf = +-preserves-≤ x y (z * x) (z * y) prf
+  (*-preserves-≤ˡ x y z prf)
+
+*-preserves-≤ʳ : (x y z : Nat) → x ≤ y → x * z ≤ y * z
+*-preserves-≤ʳ x y z prf = subst (λ a → a ≤ y * z) (*-commutative z x)
+  (subst (λ a → z * x ≤ a) (*-commutative z y) (*-preserves-≤ˡ x y z prf))
+
+*-preserves-≤ : (x y x' y' : Nat) → x ≤ y → x' ≤ y' → x * x' ≤ y * y'
+*-preserves-≤ x y x' y' prf prf' = ≤-trans (x * x') (y * x') (y * y')
+  (*-preserves-≤ʳ x y x' prf) (*-preserves-≤ˡ x' y' y prf')
+
++-reflects-≤ˡ : (x y z : Nat) → z + x ≤ z + y → x ≤ y
++-reflects-≤ˡ x y zero prf = prf
++-reflects-≤ˡ x y (suc z) prf = +-reflects-≤ˡ x y z prf
+
++-reflects-≤ʳ : (x y z : Nat) → x + z ≤ y + z → x ≤ y
++-reflects-≤ʳ x y z prf = +-reflects-≤ˡ x y z (subst (_≤ z + y) (+-commutative x z) (subst (x + z ≤_) (+-commutative y z) prf))
 ```


### PR DESCRIPTION
# Description
Adds exponentiation on the naturals, as well as some of its basic properties along with other order statements.

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely file** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".