### PR TITLE
shake: Warn when resulting HTML contains <!-- or -->

### DIFF
--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -352,7 +352,7 @@ checkMarkup :: FilePath -> Tag Text -> Action ()
 checkMarkup file (TagText txt)
   |  "<!--" `Text.isInfixOf` txt || "<!–" `Text.isInfixOf` txt
   || "-->" `Text.isInfixOf` txt  || "–>" `Text.isInfixOf` txt
-  = putWarn $ "[WARN] " ++ file ++ " contains misplaced <!-- or -->"
+  = fail $ "[WARN] " ++ file ++ " contains misplaced <!-- or -->"
 checkMarkup _ _ = pure ()
 
 


### PR DESCRIPTION
# Description

Prints a message like `[WARN] Data.Test.html contains misplaced <!-- or -->`. This isn't a fatal error right now, as I think it could get irritating for development. Happy to change this if preferred!

Ideally we'd include line numbers here, but that's going to be tricky to track and dubiously useful, as you're tracking line numbers in the HTML rather than the original Markdown/Agda. However, it should be pretty obvious when looking in the browser where the error is.

This is largely intended to track cases like the following:

~~~markdown
<!--

```agda
-- Some hidden code

-->
```

~~~