### PR TITLE
web: Include authors on each page

### DIFF
--- a/support/web/default.scss
+++ b/support/web/default.scss
@@ -577,6 +577,13 @@ div.profile {
   }
 }
 
+.author-list {
+  margin-top: 0.5em;
+  white-space: initial;
+  font-size: 0.8em;
+  font-style: italic;
+}
+
 @font-face {
   font-family: 'tgpagella';
   font-display: swap;

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -30,7 +30,7 @@
   <meta name="description" content="A formalised, explorable online resource for Homotopy Type Theory." />
   $endif$
 
-  <script src="/equations.js" type="text/javascript"></script> 
+  <script src="/equations.js" type="text/javascript"></script>
   <script src="/highlight-hover.js" type="text/javascript"></script>
 
   <noscript>
@@ -70,7 +70,7 @@
            width="32px"
            height="32px"
         />
-      
+
       <!-- Actual table of contents (separated from the rest by
       horizontal rules) -->
       <hr />
@@ -102,6 +102,7 @@
       $endif$
         <a href="all-pages.html">view all pages</a> <br />
         <a href="https://github.com/plt-amy/cubical-1lab/blob/$source$">link to source</a> <br />
+        <div class="author-list">Written by $authors$</div> <br />
       </div>
     </div>
   </aside>

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -102,7 +102,9 @@
       $endif$
         <a href="all-pages.html">view all pages</a> <br />
         <a href="https://github.com/plt-amy/cubical-1lab/blob/$source$">link to source</a> <br />
-        <div class="author-list">Written by $authors$</div> <br />
+        $if(authors)$
+        <hr /> <div class="author-list">Written by $authors$</div> <br />
+        $endif$
       </div>
     </div>
   </aside>


### PR DESCRIPTION
Adds a "Written by: xyz" section to each page:

![A screenshot of 1Lab.Path, with 'Written by Amélia Liao, Astra Kolomatskaia, Jonathan Coates and uni' on the bottom left](https://user-images.githubusercontent.com/4346137/151871697-a24cbc36-1142-4f33-8a44-e2c7d082eef4.png).

It's a little dubious (git log isn't smart enough to exclude whitespace changes), but good enough. I think!