### PR TITLE
Fix typo about monoid inverses

### DIFF
--- a/src/Algebra/Monoid.lagda.md
+++ b/src/Algebra/Monoid.lagda.md
@@ -161,8 +161,8 @@ direction, namely, that every unital semigroup is a monoid.
 A useful application of the monoid laws is in showing that _having an
 **inverse**_ is a _proprety_ of a specific element, not structure on
 that element. To make this precise: Let $e$ be an element of a monoid,
-say $(M, 1, \star)$; If there are $x$ and $y$ such that $x \star e = e$
-and $e \star y = e$, then $x = y$.
+say $(M, 1, \star)$; If there are $x$ and $y$ such that $x \star e = 1$
+and $e \star y = 1$, then $x = y$.
 
 ```agda
 monoid-inverse-unique


### PR DESCRIPTION
Fix typo where `1` was written as `e`.
