### PR TITLE
Feature: Limits and colimits

### DIFF
--- a/.macros
+++ b/.macros
@@ -1,9 +1,11 @@
 \ty:\mathrm{Type}
 \set:\mathrm{Set}
-\sets:\mathrm{Sets}
-\cat:\mathrm{Cat}
-\grpd:\mathrm{Grpd}
 \ht:\mathbf{#1}
+\prosets:\ht{Prosets}
+\sets:\ht{Sets}
+\cat:\ht{Cat}
+\strcat:\ht{Cat}_\mathrm{strict}
+\grpd:\ht{Grpd}
 \ca:\mathcal{#1}
 \igpd:\text{$\infty$-\textbf{Grpd}}
 \hra:\hookrightarrow

--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -57,7 +57,7 @@ familiar with some of the connections that HoTT has to other areas of
 mathematics, like higher category theory and topology, I recommend that
 you read the type theory section anyway!
 
-<details>
+<details class=text>
 <summary>
 **Aside**: A note on terminology.
 </summary>
@@ -517,7 +517,7 @@ call $\Omega$ a **subobject classifier**, following in the tradition of
 it means you can talk about logical propositions --- and, in the
 presence of functions, predicates --- as if they were points of a type.
 
-<details>
+<details class=text>
 <summary>
 **Aside**: More on general classifying objects.
 </summary>
@@ -583,7 +583,7 @@ one dimension higher: we'd have a classifier for "sets", but our other
 objects would look like "categories", and we wouldn't be able to
 classify those!
 
-<details>
+<details class=text>
 <summary> **Take a moment** to convince yourself that the interpretation
 of a discrete object classifier as a type of sets makes sense.</summary>
 
@@ -617,7 +617,7 @@ we would hope that an **object classifier** would classify the entire
 category $\mathrm{Core}(\mathscr{E}/x)$, keeping around _all_ of the
 maps into $x$, and keeping track of the isomorphisms between them.
 
-<details>
+<details class=text>
 <summary>**Aside**: Slice categories and cores, if you haven't heard of
 them</summary>
 
@@ -784,7 +784,7 @@ only one of the many possible interpretations of paths in those types.
 The ideas presented below are grouped in blue `<details>` elements, but
 not because they aren't important; You **should** read all of them.
 
-<details>
+<details class=text>
 <summary>
 **Idea #1**: Some types behave like sets, providing an embedding of
 "classical" equality behaviour into homotopy type theory. While these
@@ -830,7 +830,7 @@ sequences of natural numbers are not discrete, because an algorithm can
 not run forever. Any discrete type is a set, and assuming excluded
 middle, any set is discrete.
 
-<details>
+<details class=text>
 <summary>
 **Idea #2**: Some types are best understood as representing spaces, with
 intrinsic homotopic information, which we can investigate using
@@ -861,7 +861,7 @@ path in $X$ which "walks clockwise around the circle twice".
 
 </details>
 
-<details>
+<details class=text>
 <summary>
 **Idea #3**: HoTT provides a setting for doing category theory where all
 constructions are intrinsically isomorphism-invariant. Under this light,

--- a/src/Cat/Diagram/Coequaliser.lagda.md
+++ b/src/Cat/Diagram/Coequaliser.lagda.md
@@ -22,13 +22,13 @@ and $g$.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-	A & B & E \\
-	&& F
-	\arrow["f", shift left=2, from=1-1, to=1-2]
-	\arrow["g"', shift right=2, from=1-1, to=1-2]
-	\arrow[from=1-2, to=1-3]
-	\arrow[from=1-2, to=2-3]
-	\arrow["{\exists!}", dashed, from=1-3, to=2-3]
+  A & B & E \\
+  && F
+  \arrow["f", shift left=2, from=1-1, to=1-2]
+  \arrow["g"', shift right=2, from=1-1, to=1-2]
+  \arrow[from=1-2, to=1-3]
+  \arrow[from=1-2, to=2-3]
+  \arrow["{\exists!}", dashed, from=1-3, to=2-3]
 \end{tikzcd}\]
 ~~~
 

--- a/src/Cat/Diagram/Coequaliser.lagda.md
+++ b/src/Cat/Diagram/Coequaliser.lagda.md
@@ -1,0 +1,67 @@
+```agda
+open import Cat.Prelude
+
+module Cat.Diagram.Coequaliser {o ℓ} (C : Precategory o ℓ) where
+
+```
+
+<!--
+```agda
+open import Cat.Reasoning C
+private variable
+  A B : Ob
+  f g h : Hom A B
+```
+-->
+
+# Coequalisers
+
+The **coequaliser** of two maps $f, g : A \to B$ (if it exists),
+represents the largest quotient object of $B$ that identifies $f$
+and $g$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+	A & B & E \\
+	&& F
+	\arrow["f", shift left=2, from=1-1, to=1-2]
+	\arrow["g"', shift right=2, from=1-1, to=1-2]
+	\arrow[from=1-2, to=1-3]
+	\arrow[from=1-2, to=2-3]
+	\arrow["{\exists!}", dashed, from=1-3, to=2-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+record IsCoequaliser {E} (f g : Hom A B) (coeq : Hom B E) : Type (o ⊔ ℓ) where
+  field
+    coequal    : coeq ∘ f ≡ coeq ∘ g
+    coequalize : ∀ {F} {e′ : Hom B F} (p : e′ ∘ f ≡ e′ ∘ g) → Hom E F
+    universal  : ∀ {F} {e′ : Hom B F} (p : e′ ∘ f ≡ e′ ∘ g)
+                 → coequalize p ∘ coeq ≡ e′
+    unique     : ∀ {F} {e′ : Hom B F} {p : e′ ∘ f ≡ e′ ∘ g} {colim : Hom E F}
+                 → e′ ≡ colim ∘ coeq
+                 → colim ≡ coequalize p
+
+  unique₂ : (p q : h ∘ f ≡ h ∘ g) → coequalize p ≡ coequalize q
+  unique₂ p q = unique (sym (universal p))
+
+  id-coequalize : id ≡ coequalize coequal
+  id-coequalize = unique (sym (idl _))
+
+```
+
+There is also a convenient bundling of an coequalising arrow together with
+its codomain:
+
+```agda
+record Coequaliser (f g : Hom A B) : Type (o ⊔ ℓ) where
+  field
+    {coapex}  : Ob
+    coeq      : Hom B coapex
+    hasIsCoeq : IsCoequaliser f g coeq
+
+  open IsCoequaliser hasIsCoeq public
+```
+
+

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -4,7 +4,7 @@ open import Cat.Prelude
 
 import Cat.Morphism
 
-module Cat.Diagram.Limit.Colimit.Base where
+module Cat.Diagram.Colimit.Base where
 ```
 
 <!--

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -16,6 +16,9 @@ private variable
 
 The **coproduct** $P$ of two objects $A$ and $B$ (if it exists), is the
 smallest object equipped with "injection" maps $A \to P$, $B \to P$.
+It is dual to the [product].
+
+[product]: Cat.Diagram.Terminal.html
 
 We witness this notion of "smallest object" with a universal property;
 Given any other $Q$ that also admits injection maps from $A$ and $B$,

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -1,0 +1,107 @@
+```agda
+open import Cat.Prelude
+
+module Cat.Diagram.Coproduct {o h} (C : Precategory o h) where
+```
+
+<!--
+```agda
+open import Cat.Reasoning C
+private variable
+  A B : Ob
+```
+-->
+
+# Coproducts
+
+The **coproduct** $P$ of two objects $A$ and $B$ (if it exists), is the
+smallest object equipped with "injection" maps $A \to P$, $B \to P$.
+
+We witness this notion of "smallest object" with a universal property;
+Given any other $Q$ that also admits injection maps from $A$ and $B$,
+we must have a *unique* map $P \to Q$ that factors the injections into 
+$Q$. This is best explained by a commutative diagram:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+	A & P & B \\
+	& Q \\
+	& {}
+	\arrow[from=1-1, to=1-2]
+	\arrow[from=1-3, to=1-2]
+	\arrow[from=1-1, to=2-2]
+	\arrow[from=1-3, to=2-2]
+	\arrow["{\exists!}"', dashed, from=1-2, to=2-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+record IsCoproduct {A B P} (in₀ : Hom A P) (in₁ : Hom B P) : Type (o ⊔ h) where
+  field
+    [_,_]      : ∀ {Q} (inj0 : Hom A Q) (inj1 : Hom B Q) → Hom P Q
+    in₀∘factor : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ in₀ ≡ inj0
+    in₁∘factor : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ in₁ ≡ inj1
+
+    unique : ∀ {Q} {inj0 : Hom A Q} {inj1}
+           → (other : Hom P Q)
+           → other ∘ in₀ ≡ inj0
+           → other ∘ in₁ ≡ inj1
+           → other ≡ [ inj0 , inj1 ]
+
+  unique₂ : ∀ {Q} {inj0 : Hom A Q} {inj1}
+          → ∀ o1 (p1 : o1 ∘ in₀  ≡ inj0) (q1 : o1 ∘ in₁ ≡ inj1)
+          → ∀ o2 (p2 : o2 ∘ in₀  ≡ inj0) (q2 : o2 ∘ in₁ ≡ inj1)
+          → o1 ≡ o2
+  unique₂ o1 p1 q1 o2 p2 q2 = unique o1 p1 q1 ∙ sym (unique o2 p2 q2)
+```
+
+A coproduct of $A$ and $B$ is an explicit choice of coproduct diagram:
+
+```agda
+record Coproduct (A B : Ob) : Type (o ⊔ h) where
+  field
+    coapex : Ob
+    in₀ : Hom A coapex
+    in₁ : Hom A coapex
+    hasIsCoproduct : IsCoproduct in₀ in₁
+
+  open IsCoproduct hasIsCoproduct public
+
+open Coproduct
+```
+
+## Uniqueness
+
+The uniqueness argument presented here is dual to the argument
+for the [Product](agda://Cat.Diagram.Product#×-Unique).
+
+```agda
++-Unique : (c1 c2 : Coproduct A B) → coapex c1 ≅ coapex c2
++-Unique c1 c2 = makeIso c1→c2 c2→c1 c1→c2→c1 c2→c1→c2
+  where
+    module c1 = Coproduct c1
+    module c2 = Coproduct c2
+
+    c1→c2 : Hom (coapex c1) (coapex c2)
+    c1→c2 = c1.[ c2.in₀ , c2.in₁ ]
+
+    c2→c1 : Hom (coapex c2) (coapex c1)
+    c2→c1 = c2.[ c1.in₀ , c1.in₁ ]
+```
+
+```agda
+    c1→c2→c1 : c1→c2 ∘ c2→c1 ≡ id
+    c1→c2→c1 =
+      c2.unique₂ _
+        (pullr c2.in₀∘factor ∙ c1.in₀∘factor)
+        (pullr c2.in₁∘factor ∙ c1.in₁∘factor)
+        id (idl _) (idl _)
+
+    c2→c1→c2 : c2→c1 ∘ c1→c2 ≡ id
+    c2→c1→c2 =
+      c1.unique₂ _
+        (pullr c1.in₀∘factor ∙ c2.in₀∘factor)
+        (pullr c1.in₁∘factor ∙ c2.in₁∘factor)
+        id (idl _) (idl _)
+```
+

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -27,14 +27,14 @@ $Q$. This is best explained by a commutative diagram:
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-	A & P & B \\
-	& Q \\
-	& {}
-	\arrow[from=1-1, to=1-2]
-	\arrow[from=1-3, to=1-2]
-	\arrow[from=1-1, to=2-2]
-	\arrow[from=1-3, to=2-2]
-	\arrow["{\exists!}"', dashed, from=1-2, to=2-2]
+  A & P & B \\
+  & Q \\
+  & {}
+  \arrow[from=1-1, to=1-2]
+  \arrow[from=1-3, to=1-2]
+  \arrow[from=1-1, to=2-2]
+  \arrow[from=1-3, to=2-2]
+  \arrow["{\exists!}"', dashed, from=1-2, to=2-2]
 \end{tikzcd}\]
 ~~~
 

--- a/src/Cat/Diagram/Equaliser.lagda.md
+++ b/src/Cat/Diagram/Equaliser.lagda.md
@@ -1,0 +1,86 @@
+```agda
+open import Cat.Prelude
+
+module Cat.Diagram.Equaliser {ℓ ℓ′} (C : Precategory ℓ ℓ′) where
+```
+
+<!--
+```agda
+open import Cat.Reasoning C
+private variable
+  A B : Ob
+  f g h : Hom A B
+```
+-->
+
+# Equalisers
+
+The **equaliser** of two maps $f, g : A \to B$, when it exists,
+represents the largest subobject of $A$ where $f$ and $g$ agree. In this
+sense, the equaliser is the categorical generalisation of a _solution
+set_: The solution set of an equation in one variable is largest subset
+of the domain (i.e. what the variable ranges over) where the left- and
+right-hand-sides agree.
+
+```agda
+record IsEqualiser {E} (f g : Hom A B) (equ : Hom E A) : Type (ℓ ⊔ ℓ′) where
+  field
+    equal     : f ∘ equ ≡ g ∘ equ
+    limiting  : ∀ {F} {e′ : Hom F A} (p : f ∘ e′ ≡ g ∘ e′) → Hom F E
+    universal : ∀ {F} {e′ : Hom F A} {p : f ∘ e′ ≡ g ∘ e′} → equ ∘ limiting p ≡ e′
+    unique 
+      : ∀ {F} {e′ : Hom F A} {p : f ∘ e′ ≡ g ∘ e′} {lim' : Hom F E}
+      → e′ ≡ equ ∘ lim'
+      → lim' ≡ limiting p
+
+  equal-∘ : f ∘ equ ∘ h ≡ g ∘ equ ∘ h
+  equal-∘ {h = h} =
+    f ∘ equ ∘ h ≡⟨ extendl equal ⟩
+    g ∘ equ ∘ h ∎
+```
+
+We can visualise the situation using the commutative diagram below:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  E & A & B \\
+  F
+  \arrow["f", shift left=1, from=1-2, to=1-3]
+  \arrow["g"', shift right=1, from=1-2, to=1-3]
+  \arrow["{\mathrm{equ}}", hook, from=1-1, to=1-2]
+  \arrow["{\exists!}", dashed, from=2-1, to=1-1]
+  \arrow["e\prime"', from=2-1, to=1-2]
+\end{tikzcd}\]
+~~~
+
+There is also a convenient bundling of an equalising arrow together with
+its domain:
+
+```agda
+record Equaliser (f g : Hom A B) : Type (ℓ ⊔ ℓ′) where
+  field
+    {apex}  : Ob
+    equ     : Hom apex A
+    hasIsEq : IsEqualiser f g equ
+
+  open IsEqualiser hasIsEq public   
+```
+
+## Equalisers are monic
+
+As a small initial application, we prove that equaliser arrows are
+always [monic]:
+
+[monic]: Cat.Morphism.html#monos
+
+```agda
+IsEqualiser→isMonic 
+  : ∀ {E} (equ : Hom E A)
+  → IsEqualiser f g equ
+  → isMonic equ
+IsEqualiser→isMonic equ equalises g h p = 
+  g                ≡⟨ unique (sym p) ⟩
+  limiting equal-∘ ≡˘⟨ unique refl ⟩
+  h ∎
+  where open IsEqualiser equalises
+```

--- a/src/Cat/Diagram/Initial.lagda.md
+++ b/src/Cat/Diagram/Initial.lagda.md
@@ -50,7 +50,7 @@ mapped _into_ any other object. For the category of `Sets`{.Agda}, this
 is the empty set; there is no required structure beyond "being a set",
 so the empty set sufficies.
 
-<--!
+<!--
 [TODO: Reed M, 15/02/2022] Link to the categories in question
 (once the exist!)
 -->

--- a/src/Cat/Diagram/Initial.lagda.md
+++ b/src/Cat/Diagram/Initial.lagda.md
@@ -1,0 +1,87 @@
+```agda
+open import Cat.Univalent
+open import Cat.Prelude
+
+module Cat.Diagram.Initial {o h} (C : Precategory o h) where
+```
+
+<!--
+```agda
+open import Cat.Morphism C
+```
+-->
+
+# Initial objects
+
+An object $\bot$ of a category $\mathcal{C}$ is said to be **initial**
+if there exists a _unique_ map to any other object:
+
+```agda
+isInitial : Ob → Type _
+isInitial ob = ∀ x → isContr (Hom ob x)
+
+record Initial : Type (o ⊔ h) where
+  field
+    bot  : Ob
+    has⊥ : isInitial bot
+```
+
+We refer to the centre of contraction as `¡`{.Agda}. Since it inhabits a
+contractible type, it is unique.
+
+```agda
+  ¡ : ∀ {x} → Hom bot x
+  ¡ = has⊥ _ .centre
+
+  ¡-unique : ∀ {x} (h : Hom bot x) → ¡ ≡ h
+  ¡-unique = has⊥ _ .paths
+
+  ¡-unique₂ : ∀ {x} (f g : Hom bot x) → f ≡ g
+  ¡-unique₂ = isContr→isProp (has⊥ _)
+
+open Initial
+```
+
+## Intuition
+
+The intuition here is that we ought to think about an initial object
+as having "the least amount of structure possible", insofar that
+it can be mapped _into_ any other object. For the category of
+`Sets`{.Agda}, this is the empty set; there is required structure
+beyond "being a set", so the empty set sufficies.
+
+<--!
+[TODO: Reed M, 15/02/2022] Link to the categories in question
+(once the exist!)
+-->
+
+In more structured categories, the situation becomes a bit more
+interesting. Once our category has enough structure that we
+can't build maps from a totally trivial thing, the initial
+object begins to behave like a notion of **Syntax** for our category.
+The idea here is that we have a _unique_ means of interpreting
+our syntax into any other object, which is exhibited by the
+universal map `¡`{.Agda}
+
+## Uniqueness
+
+One important fact about initial objects is that they are **unique** up
+to isomorphism:
+```agda
+⊥-unique : (i i′ : Initial) → bot i ≅ bot i′
+⊥-unique i i′ = makeIso (¡ i) (¡ i′) (¡-unique₂ i′ _ _) (¡-unique₂ i _ _)
+```
+
+Additionally, if $C$ is a category, then the space of initial objects
+is a proposition:
+```agda
+⊤-contractible : isCategory C → isProp Initial
+⊤-contractible ccat x1 x2 i .bot =
+  isoToPath C ccat (⊥-unique x1 x2) i
+
+⊤-contractible ccat x1 x2 i .has⊥ ob =
+  isProp→PathP
+    (λ i → isProp-isContr
+      {A = Hom (isoToPath C ccat (⊥-unique x1 x2) i) _})
+    (x1 .has⊥ ob) (x2 .has⊥ ob) i
+```

--- a/src/Cat/Diagram/Initial.lagda.md
+++ b/src/Cat/Diagram/Initial.lagda.md
@@ -44,11 +44,11 @@ open Initial
 
 ## Intuition
 
-The intuition here is that we ought to think about an initial object
-as having "the least amount of structure possible", insofar that
-it can be mapped _into_ any other object. For the category of
-`Sets`{.Agda}, this is the empty set; there is required structure
-beyond "being a set", so the empty set sufficies.
+The intuition here is that we ought to think about an initial object as
+having "the least amount of structure possible", insofar that it can be
+mapped _into_ any other object. For the category of `Sets`{.Agda}, this
+is the empty set; there is no required structure beyond "being a set",
+so the empty set sufficies.
 
 <--!
 [TODO: Reed M, 15/02/2022] Link to the categories in question
@@ -56,24 +56,25 @@ beyond "being a set", so the empty set sufficies.
 -->
 
 In more structured categories, the situation becomes a bit more
-interesting. Once our category has enough structure that we
-can't build maps from a totally trivial thing, the initial
-object begins to behave like a notion of **Syntax** for our category.
-The idea here is that we have a _unique_ means of interpreting
-our syntax into any other object, which is exhibited by the
-universal map `¡`{.Agda}
+interesting. Once our category has enough structure that we can't build
+maps from a totally trivial thing, the initial object begins to behave
+like a notion of **Syntax** for our category.  The idea here is that we
+have a _unique_ means of interpreting our syntax into any other object,
+which is exhibited by the universal map `¡`{.Agda}
 
 ## Uniqueness
 
 One important fact about initial objects is that they are **unique** up
 to isomorphism:
+
 ```agda
 ⊥-unique : (i i′ : Initial) → bot i ≅ bot i′
 ⊥-unique i i′ = makeIso (¡ i) (¡ i′) (¡-unique₂ i′ _ _) (¡-unique₂ i _ _)
 ```
 
-Additionally, if $C$ is a category, then the space of initial objects
-is a proposition:
+Additionally, if $C$ is a category, then the space of initial objects is
+a proposition:
+
 ```agda
 ⊤-contractible : isCategory C → isProp Initial
 ⊤-contractible ccat x1 x2 i .bot =

--- a/src/Cat/Diagram/Limit/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Colimit/Base.lagda.md
@@ -1,0 +1,210 @@
+```agda
+open import Cat.Diagram.Initial
+open import Cat.Prelude
+
+import Cat.Morphism
+
+module Cat.Diagram.Limit.Colimit.Base where
+```
+
+<!--
+```agda
+private variable
+  o ℓ o′ ℓ′ : Level
+```
+-->
+
+# Idea
+
+Colimits are dual to limits [limit]; much like their cousins, they
+generalize constructions in several settings to arbitrary categories.
+A colimit (if it exists), is the "best solution" to an
+"identification problem". This is in contrast to the limit, which
+acts as a solution to an "equational problem".
+
+[limit]: Cat.Diagram.Limit.Base.html
+
+# Construction
+
+Every concrete colimit ([coproducts], [coequalisers], [initial objects])
+we have seen so far consists of roughly the same data. We begin with
+some collection of objects and morphisms, and then state that the
+colimit of that collection is some object with a universal property
+relating all of those objects and morphisms.
+
+[coproducts]: Cat.Diagra.Coproduct
+[coequalisers]: Cat.Diagra.Coequaliser
+[initial objects]: Cat.Diagra.Initial
+
+It would be convienent to be able to talk about _all_ of these
+situations at once, as opposed to on a case-by-case basis. To do this,
+we need to introduce a bit of categorical machinery: the Cocone.
+
+The first step is to generalize the "collection of objects and
+morphisms" involved. Luckily, this step involves no new ideas, just
+a change in perspective. We already have a way of describing a
+collection of objects and morphisms: it's a category! As an example,
+the starting data of a coproduct is a pair of objects, which can
+be thought of as a very simple category, with only identity morphisms.
+
+~~~{.quiver .short-2}
+\[\begin{tikzcd}
+A & B
+\end{tikzcd}\]
+~~~
+
+The next step also involves nothing more than a change in perspective.
+Let's denote our "diagram" category from earlier as $J$. Then, a means
+of picking out a $J$ shaped figure in $C$ is... a functor $F : J \to C$!
+Going back to the coproduct example, a functor from our 2 object
+category into $C$ selects 2 (not necessarily distinct!) objects in $C$.
+We this pair of category and functor a _diagram_ in $C$.
+
+```agda
+module _ {J : Precategory o ℓ} {C : Precategory o′ ℓ′} (F : Functor J C) where
+  private
+    import Cat.Reasoning J as J
+    import Cat.Reasoning C as C
+    module F = Functor F
+
+  record Cocone : Type (o ⊔ ℓ ⊔ o′ ⊔ ℓ′) where
+    no-eta-equality
+    constructor cocone
+```
+
+Now, for the actual machinery! If we want to capture the essence of
+all of our concrete examples of colimits, we a notion of an object
+equipped with maps _from_ every object in our diagram. We call this
+designated object the "coapex" of the cocone.
+
+
+```agda
+    field
+      coapex : C.Ob
+      ψ      : (x : J.Ob) → C.Hom (F.₀ x) coapex
+```
+
+If our diagram consisted of only objects, we would be done! However,
+some diagrams contan non-identity morphisms, so we need to take those
+into account as well. This bit is best understood through the lens of
+the coequaliser: in order to describe the commuting condition there,
+we want every injection map from the codomain of a morphism to
+factor through that morphism.
+
+```agda
+      commutes : ∀ {x y} (f : J.Hom x y) → ψ y C.∘ F.₁ f ≡ ψ x
+```
+
+As per usual, we define a helper lemma charaterizing the path space
+of cones:
+
+```agda
+  open Cocone
+
+  Cocone≡ : {x y : Cocone}
+              → (p : coapex x ≡ coapex y)
+              → (∀ o → PathP (λ i → C.Hom (F.₀ o) (p i)) (ψ x o) (ψ y o))
+              → x ≡ y
+  Cocone≡ p q i .coapex = p i
+  Cocone≡ p q i .ψ o = q o i
+  Cocone≡ {x = x} {y = y} p q i .commutes {x = a} {y = b} f =
+    isProp→PathP (λ i → C.Hom-set _ _ (q b i C.∘ F.₁ f) (q a i))
+      (x .commutes f) (y .commutes f) i
+```
+
+## Cocone Maps
+
+Now that we've defined cocones, we need a way to figure out how to
+express universal properties. Like most things categorical, we begin
+by considering a "cocone morphism", which will give us a category
+that we can work within. The idea here is that a morphism of cocones
+is a morphism in $C$ between the coapicies, such that all of the
+injection maps commute.
+
+```agda
+  record CoconeHom (x y : Cocone) : Type (o ⊔ ℓ′) where
+    no-eta-equality
+    constructor cocone-hom
+    field
+      hom : C.Hom (x .coapex) (y .coapex)
+      commutes : ∀ {o} → hom C.∘ x .ψ o ≡ y .ψ o
+```
+
+We define yet another helper lemma that describes the path space
+of cocone morphisms.
+
+```agda
+  open CoconeHom
+
+  CoconeHom≡ : ∀ {x y} {f g : CoconeHom x y} → f .hom ≡ g .hom → f ≡ g
+  CoconeHom≡ p i .hom = p i
+  CoconeHom≡ {x = x} {y = y} {f = f} {g = g} p i .commutes {o} j =
+    isSet→SquareP (λ i j → C.Hom-set _ _)
+      (λ j → p j C.∘ x .ψ o) (f .commutes) (g .commutes) refl i j
+```
+
+Now, we can define the category of cocones over a given diagram:
+
+```agda
+  Cocones : Precategory _ _
+  Cocones = cat where
+    open Precategory
+
+    compose : ∀ {x y z} → CoconeHom y z → CoconeHom x y → CoconeHom x z
+    compose K L .hom = K .hom C.∘ L .hom
+    compose {x = x} {y = y} {z = z} K L .commutes {o} =
+      (K .hom C.∘ L .hom) C.∘ x .ψ o ≡⟨ C.pullr (L .commutes) ⟩
+      K .hom C.∘ y .ψ o              ≡⟨ K .commutes ⟩
+      z .ψ o                         ∎
+
+    cat : Precategory _ _
+    cat .Ob = Cocone
+    cat .Hom = CoconeHom
+    cat .id = cocone-hom C.id (C.idl _)
+    cat ._∘_ = compose
+    cat .idr f = CoconeHom≡ (C.idr (f .hom))
+    cat .idl f = CoconeHom≡ (C.idl (f .hom))
+    cat .assoc f g h = CoconeHom≡ (C.assoc (f .hom) (g .hom) (h .hom))
+
+```
+
+<!--
+```agda
+    cat .Hom-set x y = isHLevel-retract 2 pack unpack pack∘unpack hl
+      where abstract
+        T : Type (o ⊔ ℓ′)
+        T = Σ[ hom ∈ C.Hom (x .coapex) (y .coapex) ]
+            (∀ o → hom C.∘ x .ψ o ≡ y .ψ o)
+
+        pack : T → CoconeHom x y
+        pack x = cocone-hom (x .fst) (x .snd _)
+
+        unpack : CoconeHom x y → T
+        unpack r = r .hom , λ _ → r .commutes
+
+        pack∘unpack : isLeftInverse pack unpack
+        pack∘unpack x i .hom = x .hom
+        pack∘unpack x i .commutes = x .commutes
+
+        hl : isSet T
+        hl = isHLevelΣ 2 (C.Hom-set _ _) 
+              (λ _ → isHLevelΠ 2 λ _ → isProp→isSet (C.Hom-set _ _ _ _))
+```
+-->
+
+## Colimits
+
+We now have all of the machinery in place! What remains is the
+universal property, which expresses that a _particular_ cocone
+is universal, in the sense that it has a _unique_ map to any other
+cocone. However, we already have something that captures this idea,
+it's the initial object! This leads to the following terse definition:
+A colimit over a diagram is an initial object in the category of
+cocones over that diagram.
+```
+  Colimit : Type _
+  Colimit = Initial Cocones
+
+  Colimit-apex : Colimit → C.Ob
+  Colimit-apex x = coapex (Initial.bot x)
+```

--- a/src/Cat/Diagram/Pullback.lagda.md
+++ b/src/Cat/Diagram/Pullback.lagda.md
@@ -1,0 +1,101 @@
+```agda
+open import Cat.Prelude
+
+module Cat.Diagram.Pullback {ℓ ℓ′} (C : Precategory ℓ ℓ′) where
+```
+
+# Pullbacks
+
+<!--
+```agda
+open import Cat.Reasoning C
+private variable
+  P′ X Y Z : Ob
+  h p₁' p₂' : Hom X Y
+```
+-->
+
+A **pullback** $X \times_Z Y$ of $f : X \to Z$ and $g : X \to Z$ is the
+[product] of $f$ and $g$ in the category $\ca{C}/Z$, the category of
+objects fibred over $Z$. We note that the fibre of $X \times_Z Y$ over
+some element $x$ of $Z$ is the product of the fibres of $f$ and $g$ over
+$x$; Hence the pullback is also called the **fibred product**.
+
+[product]: Cat.Diagram.Product.html
+
+```agda
+record IsPullback {P} (p₁ : Hom P X) (f : Hom X Z) (p₂ : Hom P Y) (g : Hom Y Z)
+  : Type (ℓ ⊔ ℓ′) where
+
+  field
+    square   : f ∘ p₁ ≡ g ∘ p₂
+```
+
+The concrete incarnation of the abstract nonsense above is that a
+pullback turns out to be a universal square like the one below. Since it
+is a product, it comes equipped with projections $\pi_1$ and $\pi_2$
+onto its factors; Since isn't merely a product of $X$ and $Y$, but
+rather of $X$ and $Y$ considered as objects over $Z$ in a specified way,
+overall square has to commute.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  P && Y \\
+  \\
+  X && Z
+  \arrow["g", from=1-3, to=3-3]
+  \arrow["f"', from=3-1, to=3-3]
+  \arrow["{\pi_1}"', from=1-1, to=3-1]
+  \arrow["{\pi_2}", from=1-1, to=1-3]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+    limiting : ∀ {P′} {p₁' : Hom P′ X} {p₂' : Hom P′ Y}
+             → f ∘ p₁' ≡ g ∘ p₂' → Hom P′ P
+    p₁∘limiting : {p : f ∘ p₁' ≡ g ∘ p₂'} → p₁ ∘ limiting p ≡ p₁'
+    p₂∘limiting : {p : f ∘ p₁' ≡ g ∘ p₂'} → p₂ ∘ limiting p ≡ p₂'
+
+    unique : {p : f ∘ p₁' ≡ g ∘ p₂'} {lim' : Hom P′ P}
+           → p₁ ∘ lim' ≡ p₁'
+           → p₂ ∘ lim' ≡ p₂'
+           → lim' ≡ limiting p
+```
+
+By universal, we mean that any other "square" (here the second "square"
+has corners $P'$, $X$, $Y$, $Z$ --- it's a bit bent) admits a unique
+factorisation that passes through $P$; We can draw the whole situation
+as in the diagram below. Note the little corner on $P$, indicating that
+the square is a pullback.
+
+~~~{.quiver .tall-2}
+\[\begin{tikzcd}
+  {P'} \\
+  & P && Y \\
+  \\
+  & X && Z
+  \arrow["g", from=2-4, to=4-4]
+  \arrow["f"', from=4-2, to=4-4]
+  \arrow["{\pi_1}"', from=2-2, to=4-2]
+  \arrow["{\pi_2}", from=2-2, to=2-4]
+  \arrow["{\exists! }", dashed, from=1-1, to=2-2]
+  \arrow["{p_2}", curve={height=-12pt}, from=1-1, to=2-4]
+  \arrow["{p_1}", curve={height=12pt}, from=1-1, to=4-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=2-2, to=4-4]
+\end{tikzcd}\]
+~~~
+
+We provide a convenient packaging of the pullback and the projection
+maps:
+
+```agda
+record Pullback (f : Hom X Z)  (g : Hom Y Z) : Type (ℓ ⊔ ℓ′) where
+  field
+    {apex} : Ob
+    p₁ : Hom apex X
+    p₂ : Hom apex Y
+    hasIsPb : IsPullback p₁ f p₂ g
+
+  open IsPullback hasIsPb public
+```

--- a/src/Cat/Diagram/Pullback.lagda.md
+++ b/src/Cat/Diagram/Pullback.lagda.md
@@ -90,7 +90,7 @@ We provide a convenient packaging of the pullback and the projection
 maps:
 
 ```agda
-record Pullback (f : Hom X Z)  (g : Hom Y Z) : Type (ℓ ⊔ ℓ′) where
+record Pullback {X Y Z} (f : Hom X Z) (g : Hom Y Z) : Type (ℓ ⊔ ℓ′) where
   field
     {apex} : Ob
     p₁ : Hom apex X

--- a/src/Cat/Diagram/Pullback.lagda.md
+++ b/src/Cat/Diagram/Pullback.lagda.md
@@ -15,7 +15,7 @@ private variable
 ```
 -->
 
-A **pullback** $X \times_Z Y$ of $f : X \to Z$ and $g : X \to Z$ is the
+A **pullback** $X \times_Z Y$ of $f : X \to Z$ and $g : Y \to Z$ is the
 [product] of $f$ and $g$ in the category $\ca{C}/Z$, the category of
 objects fibred over $Z$. We note that the fibre of $X \times_Z Y$ over
 some element $x$ of $Z$ is the product of the fibres of $f$ and $g$ over

--- a/src/Cat/Diagram/Pushout.lagda.md
+++ b/src/Cat/Diagram/Pushout.lagda.md
@@ -38,12 +38,12 @@ following shape:
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-	X & Z \\
-	Y & P
-	\arrow["f"', from=1-1, to=2-1]
-	\arrow["{i_1}", from=2-1, to=2-2]
-	\arrow["g", from=1-1, to=1-2]
-	\arrow["{i_2}"', from=1-2, to=2-2]
+  X & Z \\
+  Y & P
+  \arrow["f"', from=1-1, to=2-1]
+  \arrow["{i_1}", from=2-1, to=2-2]
+  \arrow["g", from=1-1, to=1-2]
+  \arrow["{i_2}"', from=1-2, to=2-2]
 \end{tikzcd}\]
 ~~~
 

--- a/src/Cat/Diagram/Pushout.lagda.md
+++ b/src/Cat/Diagram/Pushout.lagda.md
@@ -1,0 +1,84 @@
+```agda
+open import Cat.Prelude
+
+module Cat.Diagram.Pushout {o ℓ} (C : Precategory o ℓ) where
+
+```
+
+# Pushouts
+
+<!--
+```agda
+open import Cat.Reasoning C
+private variable
+  Q X Y Z : Ob
+  h i₁′ i₂′ : Hom X Y
+```
+-->
+
+A **pushout** $Y +_X Z$ of $f : X \to Y$ and $g : X \to Z$ is the 
+dual construction to the [pullback]. Much like the [pullback] is a
+subobject of the [product], the pushout is a quotient object of the
+[coproduct]. The maps $f$ and $g$ tell us which parts of the [coproduct]
+to identify.
+
+[pullback]: Cat.Diagram.Product.html
+[product]: Cat.Diagram.Product.html
+[coproduct]: Cat.Diagram.Coproduct.html
+
+```agda
+record IsPushout {P} (f : Hom X Y) (i₁ : Hom Y P) (g : Hom X Z) (i₂ : Hom Z P)
+  : Type (o ⊔ ℓ) where
+    field
+      square     : i₁ ∘ f ≡ i₂ ∘ g
+```
+
+The most important part of the pushout is a commutative square of the
+following shape:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+	X & Z \\
+	Y & P
+	\arrow["f"', from=1-1, to=2-1]
+	\arrow["{i_1}", from=2-1, to=2-2]
+	\arrow["g", from=1-1, to=1-2]
+	\arrow["{i_2}"', from=1-2, to=2-2]
+\end{tikzcd}\]
+~~~
+
+This can be thought of as providing "gluing instructions".
+The injection maps $i_1$ and $i_2$ embed $Y$ and $Z$ into $P$,
+and the maps $f$ and $g$ determine what parts of $Y$ and $Z$ we
+ought to identify in $P$.
+
+The universal property ensures that we only perform the minimal number
+of identifications required to make the aforementioned square commute.
+
+```agda
+      colimiting : ∀ {Q} {i₁′ : Hom Y Q} {i₂′ : Hom Z Q}
+                 → i₁′ ∘ f ≡ i₂′ ∘ g → Hom P Q
+      i₁∘colimiting : {p : i₁′ ∘ f ≡ i₂′ ∘ g} → colimiting p ∘ i₁ ≡ i₁′
+      i₂∘colimiting : {p : i₁′ ∘ f ≡ i₂′ ∘ g} → colimiting p ∘ i₂ ≡ i₂′
+
+      unique : {p : i₁′ ∘ f ≡ i₂′ ∘ g} {colim′ : Hom P Q}
+             → colim′ ∘ i₁ ≡ i₁′
+             → colim′ ∘ i₂ ≡ i₂′
+             → colim′ ≡ colimiting p
+```
+
+We provide a convenient packaging of the pushout and the injection
+maps:
+
+```agda
+record Pushout (f : Hom X Y) (g : Hom X Z) : Type (o ⊔ ℓ) where
+  field
+    {coapex} : Ob
+    i₁       : Hom Y coapex
+    i₂       : Hom Z coapex 
+    hasIsPo  : IsPushout f i₁ g i₂
+
+  open IsPushout hasIsPo public
+```
+
+

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -1,0 +1,72 @@
+```agda
+open import Cat.Univalent
+open import Cat.Prelude
+
+module Cat.Diagram.Zero {o h} (C : Precategory o h) where
+
+open import Cat.Diagram.Initial C
+open import Cat.Diagram.Terminal C
+```
+
+<!--
+```agda
+open import Cat.Reasoning C
+```
+-->
+
+# Zero Objects
+
+In some categories, `Initial`{.Agda} and `Terminal`{.Agda} objects coincide.
+When this occurs, such an object a **Zero** object.
+
+```agda
+record isZero (ob : Ob) : Type (o ⊔ h) where
+  field
+    is-initial  : isInitial ob
+    is-terminal : isTerminal ob
+
+record Zero : Type (o ⊔ h) where
+  field
+    ∅       : Ob
+    is-zero : isZero ∅
+
+  open isZero is-zero public
+
+  terminal : Terminal
+  terminal = record { top = ∅ ; has⊤ = is-terminal }
+
+  initial : Initial
+  initial = record { bot = ∅ ; has⊥ = is-initial }
+
+  open Terminal terminal public hiding (top)
+  open Initial initial public hiding (bot)
+```
+
+A curious fact about zero objects is that their existence implies that
+every hom set is inhabited!
+
+```agda
+  zero→ : ∀ {x y} → Hom x y
+  zero→ = ¡ ∘ !
+
+  zero-∘ˡ : ∀ {x y z} → (f : Hom y z) → f ∘ zero→ {x} {y} ≡ zero→
+  zero-∘ˡ f = pulll (sym (¡-unique (f ∘ ¡)))
+
+  zero-∘ʳ : ∀ {x y z} → (f : Hom x y) → zero→ {y} {z} ∘ f ≡ zero→
+  zero-∘ʳ f = pullr (sym (!-unique (! ∘ f)))
+```
+
+## Intuition
+
+<--! [TODO: Reed M, 15/02/2022]  Link to the category of groups -->
+Most categories that have zero objects have enough structure to rule out
+*totally* trivial strucutres like the empty set, but not enough
+structure to cause the initial and terminal objects to "separate".
+The canonical example here is the category of groups: the
+unit rules out a completely trivial group, yet there's nothing
+else that would require the initial object to have any more structure.
+
+Another point of interest is that any category with zero objects
+is canonically enriched in pointed sets: the `zero→`{.Agda} morphism
+from earlier acts as the designated basepoint for each of the
+hom sets.

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -16,8 +16,8 @@ open import Cat.Reasoning C
 
 # Zero Objects
 
-In some categories, `Initial`{.Agda} and `Terminal`{.Agda} objects coincide.
-When this occurs, such an object a **Zero** object.
+In some categories, `Initial`{.Agda} and `Terminal`{.Agda} objects
+coincide. When this occurs, we call the object a **zero object**.
 
 ```agda
 record isZero (ob : Ob) : Type (o ⊔ h) where
@@ -58,15 +58,15 @@ every hom set is inhabited!
 
 ## Intuition
 
-<--! [TODO: Reed M, 15/02/2022]  Link to the category of groups -->
-Most categories that have zero objects have enough structure to rule out
-*totally* trivial strucutres like the empty set, but not enough
-structure to cause the initial and terminal objects to "separate".
-The canonical example here is the category of groups: the
-unit rules out a completely trivial group, yet there's nothing
-else that would require the initial object to have any more structure.
+<!-- [TODO: Reed M, 15/02/2022]  Link to the category of groups -->
 
-Another point of interest is that any category with zero objects
-is canonically enriched in pointed sets: the `zero→`{.Agda} morphism
-from earlier acts as the designated basepoint for each of the
-hom sets.
+Most categories that have zero objects have enough structure to rule out
+*totally* trivial structures like the empty set, but not enough
+structure to cause the initial and terminal objects to "separate". The
+canonical example here is the category of groups: the unit rules out a
+completely trivial group, yet there's nothing else that would require
+the initial object to have any more structure.
+
+Another point of interest is that any category with zero objects is
+canonically enriched in pointed sets: the `zero→`{.Agda} morphism from
+earlier acts as the designated basepoint for each of the hom sets.

--- a/src/Cat/FinitelyComplete.lagda.md
+++ b/src/Cat/FinitelyComplete.lagda.md
@@ -1,0 +1,309 @@
+```agda
+open import Cat.Prelude
+
+module Cat.FinitelyComplete {ℓ ℓ'} (C : Precategory ℓ ℓ') where
+```
+
+<!--
+```agda
+open import Cat.Diagram.Equaliser C
+open import Cat.Diagram.Terminal C
+open import Cat.Diagram.Pullback C
+open import Cat.Diagram.Product C
+open import Cat.Reasoning C
+```
+-->
+
+# Finitely Complete Categories
+
+A category is said to be **finitely complete** if it admits limits for
+every diagram with a finite shape. While this condition might sound very
+strong, and thus that it would be hard to come by, it turns out we can
+get away with only the following common shapes of limits:
+
+* A [terminal object] (limit over the empty diagram)
+* Binary [products] (limits over diagrams of the form $\bullet\quad\bullet$, that is, two points)
+* Binary [equalisers] (limits over diagrams of the form $\bullet\rightrightarrows\bullet$)
+* Binary [pullbacks] (limits over diagrams of the form $\bullet\to\bullet\ot\bullet$)
+
+[terminal object]: Cat.Diagram.Terminal.html
+[Products]: Cat.Diagram.Product.html
+[Equalisers]: Cat.Diagram.Pullback.html
+[Pullbacks]: Cat.Diagram.Equaliser.html
+
+In reality, the list above has some redundancy. Since we can build
+products out of pullbacks and a terminal object, and conversely we can
+build pullbacks out of products and equalisers, either of the following
+subsets suffices:
+
+* A terminal object, binary products, binary equalisers;
+* A terminal object and binary pullbacks.
+
+```agda
+record FinitelyComplete : Type (ℓ ⊔ ℓ') where
+  field
+    terminal   : Terminal
+    products   : ∀ A B → Product A B
+    equalisers : ∀ {A B} (f g : Hom A B) → Equaliser f g
+    pullbacks  : ∀ {A B C} (f : Hom A C) (g : Hom B C) → Pullback f g
+
+  _⊗_ : Ob → Ob → Ob
+  A ⊗ B = products A B .Product.apex
+
+  Eq : ∀ {A B} (f g : Hom A B) → Ob
+  Eq f g = equalisers f g .Equaliser.apex
+
+  Pb : ∀ {A B C} (f : Hom A C) (g : Hom B C) → Ob
+  Pb f g = pullbacks f g .Pullback.apex
+
+open FinitelyComplete
+```
+
+## With equalisers
+
+We now prove that having products and equalisers suffices to have all
+pullbacks; Thus a terminal object, binary products and binary equalisers
+suffice for finite completeness.
+
+```agda
+withEqualisers 
+  : Terminal 
+  → (∀ A B → Product A B)
+  → (∀ {A B} (f g : Hom A B) → Equaliser f g)
+  → FinitelyComplete
+withEqualisers top prod equ .terminal   = top
+withEqualisers top prod equ .products   = prod
+withEqualisers top prod equ .equalisers = equ
+```
+
+We'll build the pullback of $f : X \to Z$, $g : Y \to Z$ by carving out
+the subobject of $X \times Y$ where $f$ and $g$ agree. In particular,
+the pullback we want is the object $X \times_Z Y$ in the commutative
+diagram below.
+
+~~~{.quiver .short-15}
+\[\begin{tikzcd}
+  {X\times_ZY} & {X\times Y} & Z
+  \arrow[from=1-1, to=1-2]
+  \arrow["{f\pi_1}", shift left=1, from=1-2, to=1-3]
+  \arrow["{g\pi_2}"', shift right=1, from=1-2, to=1-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+withEqualisers top prod equ .pullbacks {A} {B} {C} f g = pb where
+  module Prod = Product (prod A B)
+
+  p1 : Hom Prod.apex C
+  p1 = f ∘ Prod.π₁
+
+  p2 : Hom Prod.apex C
+  p2 = g ∘ Prod.π₂
+
+  module Equ = Equaliser (equ p1 p2)
+
+  open IsPullback
+  open Pullback
+
+  pb : Pullback f g
+  pb .apex = Equ.apex
+  pb .p₁ = Prod.π₁ ∘ Equ.equ
+  pb .p₂ = Prod.π₂ ∘ Equ.equ
+  pb .hasIsPb .square = 
+    f ∘ Prod.π₁ ∘ Equ.equ ≡⟨ (assoc _ _ _ ·· Equ.equal ·· sym (assoc _ _ _)) ⟩
+    g ∘ Prod.π₂ ∘ Equ.equ ∎
+```
+
+To show that this object really _is_ a pullback of $f$ and $g$, note
+that we can factor any pair of arrows $P' \to X$ and $P' \to Y$ through
+the Cartesian product $X \times Y$, and use the universal property of
+equalisers to factor _that_ as a unique arrow $P' \to X \times_Z Y$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {X\times_ZY} & {X\times Y} & Z \\
+  {P'}
+  \arrow[from=1-1, to=1-2]
+  \arrow["{f\pi_1}", shift left=1, from=1-2, to=1-3]
+  \arrow["{g\pi_2}"', shift right=1, from=1-2, to=1-3]
+  \arrow["{\exists!}", dashed, from=2-1, to=1-1]
+  \arrow["{\langle p_1',p_2' \rangle}"', from=2-1, to=1-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+  pb .hasIsPb .limiting {p₁' = p₁'} {p₂' = p₂'} p = 
+    Equ.limiting {e′ = Prod.⟨ p₁' , p₂' ⟩} (
+      (f ∘ Prod.π₁) ∘ Prod.⟨ p₁' , p₂' ⟩ ≡⟨ pullr Prod.π₁∘factor ⟩
+      f ∘ p₁'                            ≡⟨ p ⟩
+      g ∘ p₂'                            ≡˘⟨ pullr Prod.π₂∘factor ⟩
+      (g ∘ Prod.π₂) ∘ Prod.⟨ p₁' , p₂' ⟩ ∎
+    )
+  pb .hasIsPb .p₁∘limiting = pullr Equ.universal ∙ Prod.π₁∘factor
+  pb .hasIsPb .p₂∘limiting = pullr Equ.universal ∙ Prod.π₂∘factor
+  pb .hasIsPb .unique p q = 
+    Equ.unique (sym (Prod.unique _ (assoc _ _ _ ∙ p) (assoc _ _ _ ∙ q)))
+```
+
+## With pullbacks
+
+We'll now prove the converse: That a terminal object and pullbacks
+implies having all products, and all equalisers. 
+
+```agda
+withPullbacks 
+  : Terminal 
+  → (∀ {A B C} (f : Hom A C) (g : Hom B C) → Pullback f g)
+  → FinitelyComplete
+withPullbacks top pb = fc where
+  module top = Terminal top
+  mkprod : ∀ A B → Product A B
+```
+
+We'll start with the products, since those are simpler. Observe that we
+can complete a product diagram (like the one on the left) to a pullback
+diagram (like the one on the right) by adding in the unique arrows into
+the terminal object $*$. 
+
+<div class=mathpar>
+
+~~~{.quiver .tall-2}
+\[\begin{tikzcd}
+  {P'} \\
+  & {A\times B} && B \\
+  \\
+  & A
+  \arrow["g", from=2-2, to=2-4]
+  \arrow["f"', from=2-2, to=4-2]
+  \arrow["{\langle f,g\rangle}", dashed, from=1-1, to=2-2]
+  \arrow[curve={height=-12pt}, from=1-1, to=2-4]
+  \arrow[curve={height=12pt}, from=1-1, to=4-2]
+\end{tikzcd}\]
+~~~
+
+~~~{.quiver .tall-2}
+\[\begin{tikzcd}
+  {P'} \\
+  & {A\times B} && B \\
+  \\
+  & A && {*}
+  \arrow["g", from=2-2, to=2-4]
+  \arrow["f"', from=2-2, to=4-2]
+  \arrow["{\langle f,g\rangle}", dashed, from=1-1, to=2-2]
+  \arrow[curve={height=-12pt}, from=1-1, to=2-4]
+  \arrow[curve={height=12pt}, from=1-1, to=4-2]
+  \arrow["{!}", from=2-4, to=4-4]
+  \arrow["{!}"', from=4-2, to=4-4]
+\end{tikzcd}\]
+~~~
+
+</div>
+```agda
+  mkprod A B = prod where
+    module Pb = Pullback (pb (top.! {x = A}) (top.! {x = B}))
+    open IsProduct
+    open Product
+
+    prod : Product A B
+    prod .apex = Pb.apex
+    prod .π₁ = Pb.p₁
+    prod .π₂ = Pb.p₂
+    prod .hasIsProduct .IsProduct.⟨_,_⟩ p1' p2' = 
+      Pb.limiting {p₁' = p1'} {p₂' = p2'} (top.!-unique₂ _ _)
+    prod .hasIsProduct .IsProduct.π₁∘factor = Pb.p₁∘limiting
+    prod .hasIsProduct .IsProduct.π₂∘factor = Pb.p₂∘limiting
+    prod .hasIsProduct .unique other p q = Pb.unique p q
+
+  mkeq : ∀ {A B} (f g : Hom A B) → Equaliser f g
+  mkeq {A = A} {B} f g = eq where
+```
+
+For equalisers, the situation is a bit more complicated. Recall that, by
+analogy with the case in Set, we can consider the equaliser to be the
+solution set of $f(x) = g(x)$, for some $f, g : A \to B$. We can
+consider the two sides of this equation as a _single_ map $\langle f, g
+\rangle : A \to B \times B$; The equation is solved where _this_ pairing
+map equals some $(x,x)$. We can thus build equalisers by pulling back
+along the diagonal map:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {\mathrm{eq}(f,g)} && A \\
+  \\
+  B && {B \times B}
+  \arrow["{\mathrm{equ}}", from=1-1, to=1-3]
+  \arrow[from=1-1, to=3-1]
+  \arrow["{\langle f,g\rangle}", from=1-3, to=3-3]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=3-3]
+  \arrow["{\langle \mathrm{id}, \mathrm{id}\rangle}"', from=3-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+⚠️
+
+```
+    module Bb = Product (mkprod B B)
+    ⟨id,id⟩ : Hom B Bb.apex
+    ⟨id,id⟩ = Bb.⟨ id , id ⟩
+
+    ⟨f,g⟩ : Hom A Bb.apex
+    ⟨f,g⟩ = Bb.⟨ f , g ⟩
+
+    module Pb = Pullback (pb ⟨id,id⟩ ⟨f,g⟩)
+
+    open IsEqualiser
+    open Equaliser
+
+    eq : Equaliser f g
+    eq .apex = Pb.apex
+    eq .equ = Pb.p₂
+    eq .hasIsEq .equal = 
+      f ∘ Pb.p₂               ≡˘⟨ pulll Bb.π₁∘factor ⟩
+      Bb.π₁ ∘ ⟨f,g⟩ ∘ Pb.p₂   ≡⟨ ap (Bb.π₁ ∘_) (sym Pb.square) ⟩
+      Bb.π₁ ∘ ⟨id,id⟩ ∘ Pb.p₁ ≡⟨ pulll Bb.π₁∘factor ∙ sym (pulll Bb.π₂∘factor) ⟩
+      Bb.π₂ ∘ ⟨id,id⟩ ∘ Pb.p₁ ≡⟨ ap (Bb.π₂ ∘_) Pb.square ⟩
+      Bb.π₂ ∘ ⟨f,g⟩ ∘ Pb.p₂   ≡⟨ pulll Bb.π₂∘factor ⟩
+      g ∘ Pb.p₂               ∎
+
+    eq .hasIsEq .limiting {e′ = e′} p = 
+      Pb.limiting (Bb.unique₂ _ refl refl _ (sym p1) (sym p2))
+      where
+        p1 : Bb.π₁ ∘ ⟨id,id⟩ ∘ f ∘ e′ ≡ Bb.π₁ ∘ ⟨f,g⟩ ∘ e′
+        p1 = 
+          Bb.π₁ ∘ ⟨id,id⟩ ∘ f ∘ e′   ≡⟨ assoc _ _ _ ⟩
+          (Bb.π₁ ∘ ⟨id,id⟩) ∘ f ∘ e′ ≡⟨ ap (_∘ _) Bb.π₁∘factor ⟩
+          id ∘ f ∘ e′                ≡⟨ idl _ ⟩
+          f ∘ e′                     ≡˘⟨ pulll Bb.π₁∘factor ⟩
+          Bb.π₁ ∘ ⟨f,g⟩ ∘ e′         ∎
+        
+        p2 : Bb.π₂ ∘ ⟨id,id⟩ ∘ f ∘ e′ ≡ Bb.π₂ ∘ ⟨f,g⟩ ∘ e′
+        p2 =
+          Bb.π₂ ∘ ⟨id,id⟩ ∘ f ∘ e′   ≡⟨ assoc _ _ _ ⟩
+          (Bb.π₂ ∘ ⟨id,id⟩) ∘ f ∘ e′ ≡⟨ ap (_∘ _) Bb.π₂∘factor ⟩
+          id ∘ f ∘ e′                ≡⟨ idl _ ⟩
+          f ∘ e′                     ≡⟨ p ⟩
+          g ∘ e′                     ≡˘⟨ pulll Bb.π₂∘factor ⟩
+          Bb.π₂ ∘ ⟨f,g⟩ ∘ e′         ∎
+
+    eq .hasIsEq .universal = Pb.p₂∘limiting
+    eq .hasIsEq .unique {F} {e′ = e′} {lim' = lim'} e′=p₂∘l = 
+      Pb.unique path (sym e′=p₂∘l) 
+      where
+        path : Pb.p₁ ∘ lim' ≡ f ∘ e′
+        path = 
+          Pb.p₁ ∘ lim'                   ≡⟨ insertl Bb.π₁∘factor ⟩
+          Bb.π₁ ∘ ⟨id,id⟩ ∘ Pb.p₁ ∘ lim' ≡⟨ ap (Bb.π₁ ∘_) (extendl Pb.square) ⟩
+          Bb.π₁ ∘ ⟨f,g⟩ ∘ Pb.p₂ ∘ lim'   ≡⟨ ap (Bb.π₁ ∘_) (ap (⟨f,g⟩ ∘_) (sym e′=p₂∘l)) ⟩
+          Bb.π₁ ∘ ⟨f,g⟩ ∘ e′             ≡⟨ pulll Bb.π₁∘factor ⟩
+          f ∘ e′                         ∎
+```
+
+Putting it all together into a record we get our proof of finite completeness:
+
+```agda
+  fc : FinitelyComplete
+  fc .terminal = top
+  fc .products = mkprod
+  fc .equalisers = mkeq
+  fc .pullbacks = pb
+```

--- a/src/Cat/FinitelyComplete/Instances/Sets.lagda.md
+++ b/src/Cat/FinitelyComplete/Instances/Sets.lagda.md
@@ -1,0 +1,101 @@
+```agda
+open import Cat.FinitelyComplete
+open import Cat.Prelude
+
+module Cat.FinitelyComplete.Instances.Sets {ℓ} where
+```
+
+<!--
+```agda
+open import Cat.Diagram.Equaliser (Sets ℓ)
+open import Cat.Diagram.Pullback (Sets ℓ)
+open import Cat.Diagram.Terminal (Sets ℓ)
+open import Cat.Diagram.Product (Sets ℓ)
+open import Cat.Reasoning (Sets ℓ)
+
+private variable
+  A B : Set ℓ
+  f g : Hom A B
+
+open Terminal
+open IsProduct
+open Product
+open IsPullback
+open Pullback
+open IsEqualiser
+open Equaliser
+```
+-->
+
+# Finite set-limits
+
+We prove that the category of `Sets`{.Agda} admits finite limits. The
+terminal object is given by the 1-point set:
+
+```agda
+Sets-terminal : Terminal
+Sets-terminal .Terminal.top = Lift _  ⊤ , isProp→isSet (λ _ _ → refl)
+Sets-terminal .Terminal.has⊤ _ = isHLevel→ 0 (contr (lift tt) λ x i → lift tt)
+```
+
+Products are given by product sets:
+
+```agda
+Sets-products : (A B : Set ℓ) → Product A B
+Sets-products A B .apex = (A .fst × B .fst) , isHLevel× 2 (A .snd) (B .snd)
+Sets-products A B .π₁ = fst
+Sets-products A B .π₂ = snd
+Sets-products A B .hasIsProduct .⟨_,_⟩ f g x = f x , g x
+Sets-products A B .hasIsProduct .π₁∘factor = refl
+Sets-products A B .hasIsProduct .π₂∘factor = refl
+Sets-products A B .hasIsProduct .unique o p q i x = p i x , q i x
+```
+
+Equalisers are given by carving out the subset of $A$ where $f$ and $g$ agree
+using $\Sigma$:
+
+```agda
+Sets-equalisers : (f g : Hom A B) → Equaliser {A = A} {B = B} f g
+Sets-equalisers {A = A , As} {B = B , Bs} f g = eq where
+  eq : Equaliser f g
+  eq .apex = Σ[ x ∈ A ] (f x ≡ g x) , isHLevelΣ 2 As λ _ → isProp→isSet (Bs _ _)
+  eq .equ = fst
+  eq .hasIsEq .equal = funext snd
+  eq .hasIsEq .limiting {e′ = e′} p x = e′ x , happly p x
+  eq .hasIsEq .universal = refl
+  eq .hasIsEq .unique {p = p} q = 
+    funext λ x → Σ≡Prop (λ _ → Bs _ _) (happly (sym q) x)
+```
+
+Pullbacks are the same, but carving out a subset of $A \times B$.
+
+```agda
+Sets-pullbacks : ∀ {A B C} (f : Hom A C) (g : Hom B C) 
+               → Pullback {X = A} {Y = B} {Z = C} f g
+Sets-pullbacks {A = A , As} {B = B , Bs} {C = C , Cs} f g = pb where
+  pb : Pullback f g
+  pb .apex .fst = Σ[ x ∈ A ] Σ[ y ∈ B ] (f x ≡ g y)
+  pb .apex .snd = isHLevelΣ 2 As λ _ → isHLevelΣ 2 Bs λ _ → isProp→isSet (Cs _ _)
+  pb .p₁ (x , _ , _) = x
+  pb .p₂ (_ , y , _) = y
+  pb .hasIsPb .square = funext (snd ⊙ snd)
+  pb .hasIsPb .limiting {p₁' = p₁'} {p₂'} p a = p₁' a , p₂' a , happly p a
+  pb .hasIsPb .p₁∘limiting = refl
+  pb .hasIsPb .p₂∘limiting = refl
+  pb .hasIsPb .unique {p = p} {lim' = lim'} q r i x = 
+    q i x , r i x , 
+    λ j → isSet→SquareP (λ i j → Cs) 
+      (λ j → f (q j x)) (λ j → lim' x .snd .snd j) (happly p x) (λ j → g (r j x)) i j
+```
+
+Hence, `Sets`{.Agda} is finitely complete:
+
+```agda
+open FinitelyComplete
+
+FinitelyComplete-Sets : FinitelyComplete (Sets ℓ)
+FinitelyComplete-Sets .terminal = Sets-terminal
+FinitelyComplete-Sets .products = Sets-products
+FinitelyComplete-Sets .equalisers = Sets-equalisers
+FinitelyComplete-Sets .pullbacks = Sets-pullbacks
+```

--- a/src/Cat/Instances/Comma.lagda.md
+++ b/src/Cat/Instances/Comma.lagda.md
@@ -99,8 +99,8 @@ component of a [naturality square].
       module b = ↓Obj b
 
     field
-      α : Hom A a.x b.x
-      β : Hom B a.y b.y
+      {α} : Hom A a.x b.x
+      {β} : Hom B a.y b.y
       sq : b.map C.∘ F₁ F α ≡ F₁ G β C.∘ a.map
 ```
 
@@ -220,7 +220,7 @@ square.
 
 <!--
 ```agda
-module _ {A : Precategory ao ah} {B : Precategory ao bh} where
+module _ {A : Precategory ao ah} {B : Precategory bo bh} where
   private module A = Precategory A
 
   infix 4 _↙_ _↘_

--- a/src/Cat/Instances/Comma.lagda.md
+++ b/src/Cat/Instances/Comma.lagda.md
@@ -1,0 +1,238 @@
+```agda
+open import Cat.Instances.Functor
+open import Cat.Prelude
+
+module Cat.Instances.Comma where
+```
+
+<!--
+```agda
+private variable
+  o h ao ah bo bh : Level
+  A B C : Precategory o h
+open Precategory
+open Functor
+```
+-->
+
+# Comma categories
+
+The **comma category** of two functors $F : \ca{A} \to \ca{C}$ and $G :
+\ca{B} \to \ca{C}$ with common domain, written $F \downarrow G$, is the
+directed, bicategorical analogue of a [pullback] square. It consists of
+maps in $\ca{C}$ which all have their domain in the image of $F$, and
+codomain in the image of $G$.
+
+[pullback]: Cat.Diagram.Pullback.html
+
+The comma category is the universal way of completing a cospan of
+functors $A \to C \ot B$ to a homotopy commutative square like the one
+below. Note the similarity with a pullback square; However, since this
+is a bicategorical limit, rather than having an _equality_ witnessing
+the square commutes, we have a natural transformation $\theta$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {F\downarrow G} && \mathcal{A} \\
+  \\
+  \mathcal{B}     && \mathcal{C}
+  \arrow["F", from=1-3, to=3-3]
+  \arrow["G"', from=3-1, to=3-3]
+  \arrow["{\mathrm{dom}}", from=1-1, to=1-3]
+  \arrow["{\mathrm{cod}}"', from=1-1, to=3-1]
+  \arrow["\theta"{description}, Rightarrow, from=1-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+<!--
+```agda
+module 
+  _ {A : Precategory ao ah} 
+    {B : Precategory bo bh} 
+    {C : Precategory o h} 
+    (F : Functor A C) (G : Functor B C) where
+  
+  private 
+    module A = Precategory A
+    module B = Precategory B
+    import Cat.Reasoning C as C
+```
+-->
+
+The objects in $F \downarrow G$ are given by triples $(x, y, f)$ where
+$x : \ca{A}$, $y : \ca{B}$, and $f : F(x) \to G(y)$.
+
+```agda
+  record ↓Obj : Type (h ⊔ ao ⊔ bo) where
+    no-eta-equality
+    field
+      {x} : Ob A
+      {y} : Ob B
+      map : Hom C (F₀ F x) (F₀ G y)
+```
+
+A morphism from $(x_a, y_a, f_a) \to (x_b, y_b, f_b)$ is given by a pair
+of maps $\alpha : x_a \to x_b$ and $\beta : y_a \to y_b$, such that the
+square below commutes. Note that this is exactly the data of one
+component of a [naturality square].
+
+[naturality square]: Cat.Base.html#natural-transformations
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {F(x_a)} && {G(y_a)} \\
+  \\
+  {F(x_b)} && {G(y_b)}
+  \arrow["{f_b}"', from=3-1, to=3-3]
+  \arrow["{f_a}", from=1-1, to=1-3]
+  \arrow["{F(\alpha)}"', from=1-1, to=3-1]
+  \arrow["{G(\beta)}", from=1-3, to=3-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  record ↓Hom (a b : ↓Obj) : Type (h ⊔ bh ⊔ ah) where
+    no-eta-equality
+    private
+      module a = ↓Obj a
+      module b = ↓Obj b
+
+    field
+      α : Hom A a.x b.x
+      β : Hom B a.y b.y
+      sq : b.map C.∘ F₁ F α ≡ F₁ G β C.∘ a.map
+```
+
+We omit routine characterisations of equality in `↓Hom`{.Agda} from the
+page: `↓Hom-path`{.Agda} and `↓Hom-set`{.Agda}.
+
+<!--
+```agda
+  ↓Hom-path : ∀ {x y} {f g : ↓Hom x y}
+            → (f .↓Hom.α ≡ g .↓Hom.α)
+            → (f .↓Hom.β ≡ g .↓Hom.β)
+            → f ≡ g
+  ↓Hom-path p q i .↓Hom.α = p i
+  ↓Hom-path p q i .↓Hom.β = q i
+  ↓Hom-path {x} {y} {f} {g} p q i .↓Hom.sq = 
+    isProp→PathP (λ i → C.Hom-set _ _ (↓Obj.map y C.∘ F₁ F (p i)) 
+                                      (F₁ G (q i) C.∘ ↓Obj.map x))
+      (f .↓Hom.sq) (g .↓Hom.sq) i
+
+  ↓Hom-set : ∀ x y → isSet (↓Hom x y)
+  ↓Hom-set a b = hl' where abstract
+    module a = ↓Obj a
+    module b = ↓Obj b
+
+    T : Type (h ⊔ bh ⊔ ah)
+    T = 
+      Σ[ α ∈ Hom A a.x b.x ] 
+      Σ[ β ∈ Hom B a.y b.y ] 
+      (b.map C.∘ F₁ F α ≡ F₁ G β C.∘ a.map)
+
+    encode : T → ↓Hom a b
+    encode (α , β , sq) .↓Hom.α = α
+    encode (α , β , sq) .↓Hom.β = β
+    encode (α , β , sq) .↓Hom.sq = sq
+
+    decode : ↓Hom a b → T
+    decode r = r .↓Hom.α , r .↓Hom.β , r .↓Hom.sq
+
+    hl : isSet T
+    hl = isHLevelΣ 2 (A.Hom-set _ _) λ _ → 
+         isHLevelΣ 2 (B.Hom-set _ _) λ _ →
+         isProp→isSet (C.Hom-set _ _ _ _)
+
+    encode∘decode : isLeftInverse encode decode
+    encode∘decode x i .↓Hom.α  = x .↓Hom.α
+    encode∘decode x i .↓Hom.β  = x .↓Hom.β
+    encode∘decode x i .↓Hom.sq = x .↓Hom.sq
+
+    hl' : isSet (↓Hom a b)
+    hl' = isHLevel-retract 2 encode decode encode∘decode hl
+```
+-->
+
+Identities and compositions are given componentwise:
+
+```agda
+  ↓id : ∀ {a} → ↓Hom a a
+  ↓id .↓Hom.α = A.id
+  ↓id .↓Hom.β = B.id
+  ↓id .↓Hom.sq = ap (_ C.∘_) (F-id F) ·· C.id-comm ·· ap (C._∘ _) (sym (F-id G))
+
+  ↓∘ : ∀ {a b c} → ↓Hom b c → ↓Hom a b → ↓Hom a c
+  ↓∘ {a} {b} {c} g f = composite where
+    open ↓Hom
+
+    module a = ↓Obj a
+    module b = ↓Obj b
+    module c = ↓Obj c
+    module f = ↓Hom f
+    module g = ↓Hom g
+
+    composite : ↓Hom a c
+    composite .α = g.α A.∘ f.α
+    composite .β = g.β B.∘ f.β
+    composite .sq = 
+      c.map C.∘ F₁ F (g.α A.∘ f.α)    ≡⟨ ap (_ C.∘_) (F-∘ F _ _) ⟩
+      c.map C.∘ F₁ F g.α C.∘ F₁ F f.α ≡⟨ C.extendl g.sq ⟩
+      F₁ G g.β C.∘ b.map C.∘ F₁ F f.α ≡⟨ ap (_ C.∘_) f.sq ⟩
+      F₁ G g.β C.∘ F₁ G f.β C.∘ a.map ≡⟨ C.pulll (sym (F-∘ G _ _)) ⟩
+      F₁ G (g.β B.∘ f.β) C.∘ a.map    ∎
+```
+
+This assembles into a precategory.
+
+```agda
+  _↓_ : Precategory _ _
+  _↓_ .Ob = ↓Obj
+  _↓_ .Hom = ↓Hom
+  _↓_ .Hom-set = ↓Hom-set
+  _↓_ .id = ↓id
+  _↓_ ._∘_ = ↓∘
+  _↓_ .idr f = ↓Hom-path (A.idr _) (B.idr _)
+  _↓_ .idl f = ↓Hom-path (A.idl _) (B.idl _)
+  _↓_ .assoc f g h = ↓Hom-path (A.assoc _ _ _) (B.assoc _ _ _)
+```
+
+We also have the projection functors onto the factors, and the natural
+transformation $\theta$ witnessing "directed commutativity" of the
+square.
+
+```agda
+  Dom : Functor _↓_ A
+  Dom .F₀ = ↓Obj.x
+  Dom .F₁ = ↓Hom.α
+  Dom .F-id = refl
+  Dom .F-∘ _ _ = refl
+
+  Cod : Functor _↓_ B
+  Cod .F₀ = ↓Obj.y
+  Cod .F₁ = ↓Hom.β
+  Cod .F-id = refl
+  Cod .F-∘ _ _ = refl
+
+  θ : (F F∘ Dom) => (G F∘ Cod)
+  θ = NT (λ x → x .↓Obj.map) λ x y f → f .↓Hom.sq
+```
+
+<!--
+```agda
+module _ {A : Precategory ao ah} {B : Precategory ao bh} where
+  private module A = Precategory A
+
+  const! : Ob A → Functor B A
+  const! x .F₀ _ = x
+  const! x .F₁ _ = A.id
+  const! x .F-id = refl
+  const! x .F-∘ _ _ = sym (A.idl _)
+
+  infix 4 _↙_ _↘_
+  _↙_ : A.Ob → Functor B A → Precategory _ _
+  X ↙ T = const! X ↓ T
+
+  _↘_ : Functor B A → A.Ob → Precategory _ _
+  S ↘ X = S ↓ const! X
+```
+-->

--- a/src/Cat/Instances/Comma.lagda.md
+++ b/src/Cat/Instances/Comma.lagda.md
@@ -1,4 +1,5 @@
 ```agda
+open import Cat.Instances.Terminal
 open import Cat.Instances.Functor
 open import Cat.Prelude
 
@@ -221,12 +222,6 @@ square.
 ```agda
 module _ {A : Precategory ao ah} {B : Precategory ao bh} where
   private module A = Precategory A
-
-  const! : Ob A → Functor B A
-  const! x .F₀ _ = x
-  const! x .F₁ _ = A.id
-  const! x .F-id = refl
-  const! x .F-∘ _ _ = sym (A.idl _)
 
   infix 4 _↙_ _↘_
   _↙_ : A.Ob → Functor B A → Precategory _ _

--- a/src/Cat/Instances/StrictCat.lagda.md
+++ b/src/Cat/Instances/StrictCat.lagda.md
@@ -25,7 +25,7 @@ We call a precategory **strict** if its space of objects is a
 `Set`{.Agda ident=isSet.}. While general precategories are too
 homotopically interesting to fit into a `Precategory`{.Agda} (because
 functor spaces will not, in general, be h-sets), the strict categories
-_do_ form a precategory, which we denote $\cat_{\mathrm{strict}}$.
+_do_ form a precategory, which we denote $\strcat$.
 
 <!--
 ```agda

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -24,7 +24,7 @@ open _⊣_
 
 # StrictCat is "cohesive"
 
-We prove that the category $\cat_{\mathrm{strict}}$ admits an adjoint
+We prove that the category $\strcat$ admits an adjoint
 quadruple
 
 $$
@@ -155,9 +155,9 @@ Fortunately the triangle identities are straightforwardly checked.
 
 The _codiscrete_ category on a set $X$ is the strict category with
 object space $X$, and _all_ hom-spaces contractible. The assignment of
-codiscrete categories extends to a functor $\sets \to
-\cat_{\mathrm{strict}}$, where we lift functions to act on object parts
-and the action on morphisms is trivial.
+codiscrete categories extends to a functor $\sets \to \strcat$, where we
+lift functions to act on object parts and the action on morphisms is
+trivial.
 
 ```agda
 Codisc : Functor (Sets ℓ) (StrictCat ℓ ℓ)

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -326,13 +326,9 @@ the same set we started with.
 The triangle identities are again straightforwardly checked.
 
 ```agda
-  adj .zig {x} = 
-    funext (Coeq-elimProp (λ _ → squash _ _) 
-      (Coeq-elimProp (λ _ → squash _ _) λ x → refl))
+  adj .zig {x} = funext (Coeq-elimProp (λ _ → squash _ _) λ x → refl)
 
-  adj .zag = 
-    Functor≡ (Coeq-elimProp (λ _ → squash _ _) λ _ → refl) 
-      λ f → isSet→SquareP (λ _ _ → squash) _ _ _ _
+  adj .zag = Functor≡ (λ x → refl) λ f → refl
 ```
 
 Furthermore, we can prove that the connected components of a product

--- a/src/Cat/Instances/Terminal.lagda.md
+++ b/src/Cat/Instances/Terminal.lagda.md
@@ -1,0 +1,37 @@
+```agda
+open import 1Lab.Prelude
+open import Cat.Base
+
+module Cat.Instances.Terminal where
+```
+
+<!--
+```agda
+open Precategory
+```
+-->
+
+The **terminal category** is the category with a single object, and only
+trivial morphisms.
+
+```agda
+⊤Cat : Precategory lzero lzero
+⊤Cat .Ob = ⊤
+⊤Cat .Hom _ _ = ⊤
+⊤Cat .Hom-set _ _ _ _ _ _ _ _ = tt
+⊤Cat .Precategory.id = tt
+⊤Cat .Precategory._∘_ _ _ = tt
+⊤Cat .idr _ _ = tt
+⊤Cat .idl _ _ = tt
+⊤Cat .assoc _ _ _ _ = tt
+
+module _ {o h} {A : Precategory o h} where
+  private module A = Precategory A
+  open Functor
+
+  const! : Ob A → Functor ⊤Cat A
+  const! x .F₀ _ = x
+  const! x .F₁ _ = A.id
+  const! x .F-id = refl
+  const! x .F-∘ _ _ = sym (A.idl _)
+```

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -1,5 +1,7 @@
 ```agda
-open import Cat.Prelude
+open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_)
+open import Cat.Solver
+open import Cat.Base
 
 module Cat.Morphism {o h} (C : Precategory o h) where
 ```

--- a/src/Cat/Prelude.agda
+++ b/src/Cat/Prelude.agda
@@ -15,3 +15,6 @@ open import Data.Set.Coequaliser public
 
 open import Cat.Base public
 open import Cat.Solver public
+open import Cat.Univalent
+  using ( isCategory )
+  public

--- a/src/Cat/Thin.lagda.md
+++ b/src/Cat/Thin.lagda.md
@@ -339,7 +339,7 @@ Free⊣Forget .counit .is-natural x y f =
   Functor≡ (λ _ → refl) λ f → y .Proset.isThin _ _ _ _
 
 Free⊣Forget .zig = Functor≡ (λ _ → refl) λ _ → squash _ _
-Free⊣Forget .zag = Functor≡ (λ _ → refl) λ _ → squash _ _
+Free⊣Forget .zag = Functor≡ (λ _ → refl) λ _ → refl
 ```
 
 ## Poset completions

--- a/src/Cat/Thin.lagda.md
+++ b/src/Cat/Thin.lagda.md
@@ -1,0 +1,348 @@
+```agda
+open import Cat.Instances.StrictCat
+open import Cat.Instances.Functor
+open import Cat.Functor.Adjoint
+open import Cat.Prelude
+
+open import Data.Set.Coequaliser
+
+module Cat.Thin where
+```
+
+<!--
+```agda
+private variable
+  o h o′ h′ : Level
+open Functor
+open _⊣_
+open _=>_
+_ = refl
+```
+-->
+
+# Thin categories
+
+A category is called **thin** if all of its hom-sets are
+[_propositions_] rather than sets. Furthermore, we require that the
+space of objects be a set; In other words, a thin category is
+necessarily [strict].
+
+[_propositions_]: 1Lab.HLevel.html#isProp
+[strict]: Cat.Instances.StrictCat.html
+
+```agda
+record isThinCat (C : Precategory o h) : Type (o ⊔ h) where
+  open Precategory C
+  field
+    isStrict : isSet Ob
+    isThin : ∀ A B → isProp (Hom A B)
+```
+
+To avoid Agda record weirdness, we package `isThinCat`{.Agda} into a
+convenient packaged record together with the underlying category.
+
+```agda
+record Proset (o h : Level) : Type (lsuc (o ⊔ h)) where
+  no-eta-equality
+  field
+    {underlying} : Precategory o h
+    hasIsThin    : isThinCat underlying
+
+  open Precategory underlying public
+  open isThinCat hasIsThin public
+```
+
+The collection of all thin categories assembles into a subcategory of
+`StrictCat`{.Agda}, which we call `Proset`{.Agda}.
+
+```agda
+Prosets : ∀ o h → Precategory (lsuc (o ⊔ h)) (o ⊔ h)
+Prosets o h = proset where
+  open Precategory
+  open Proset
+
+  proset : Precategory _ _
+  proset .Ob = Proset o h
+  proset .Hom C D = Functor (C .underlying) (D .underlying)
+  proset .Hom-set _ D = isSet-Functor (D .isStrict)
+  proset .id = Id
+  proset ._∘_ = _F∘_
+  proset .idr f = Functor≡ (λ _ → refl) λ _ → refl
+  proset .idl f = Functor≡ (λ _ → refl) λ _ → refl
+  proset .assoc f g h = Functor≡ (λ _ → refl) λ _ → refl
+```
+
+We also have a convenience function for making any set with a preorder
+into a `ThinCat`{.Agda}.
+
+```agda
+module _ where
+  open Proset
+
+  makeProset : ∀ {ℓ ℓ'} {A : Type ℓ} {R : A → A → Type ℓ'}
+             → isSet A
+             → (∀ {x} → R x x)
+             → (∀ {x y z} → R x y → R y z → R x z)
+             → (∀ {x y} → isProp (R x y))
+             → Proset ℓ ℓ'
+  makeProset {A = A} {R} Aset Rrefl Rtrans Rprop = tc where
+    open Precategory
+
+    tc : Proset _ _
+    tc .underlying .Ob          = A
+    tc .underlying .Hom         = R
+    tc .underlying .Hom-set _ _ = isProp→isSet Rprop
+    tc .underlying .id          = Rrefl
+    tc .underlying ._∘_ f g     = Rtrans g f
+    tc .underlying .idr f       = Rprop _ _
+    tc .underlying .idl f       = Rprop _ _
+    tc .underlying .assoc f g h = Rprop _ _
+
+    tc .hasIsThin .isThinCat.isStrict = Aset
+    tc .hasIsThin .isThinCat.isThin A B x y = Rprop x y
+```
+
+# Posets
+
+We refer to a [univalent] `thin`{.Agda ident=isThinCat} category as a
+**poset**, short for partially-ordered set. Recall that a category
+$\ca{C}$ is _univalent_ when the type $\sum_{(B : \ca{C})} A \cong B$ is
+contractible for any fixed $A : \ca{C}$ or (more useful here) we have a
+function $\mathrm{isoToPath} : A \cong B \to A \equiv B$ sending the
+identity isomorphism to `refl`{.Agda}. 
+
+In a thin category, any pair of maps $(A \to B) \times (B \ot A)$ is an
+isomorphism, so in effect we have a map $(A \to B) \times (B \to A) \to
+(A \equiv B)$: If a thin category is a preordered set, then a
+_univalent_ thin category is a partially ordered set.
+
+```agda
+record Poset (o h : Level) : Type (lsuc (o ⊔ h)) where
+  no-eta-equality
+  field
+    {underlying}   : Precategory o h
+    hasIsThin      : isThinCat underlying
+    hasIsUnivalent : isCategory underlying
+    
+  open Precategory underlying public
+  open isThinCat hasIsThin public
+
+  open import Cat.Univalent underlying
+```
+
+Sincce posets are most commonly considered in the context of order
+theory, we abbreviate their $\hom$-props by $(a \le b)$. Similarly, we
+rename the identity, composition and univalence operations to
+order-theoretic names.
+
+```agda
+  _≤_ : Ob → Ob → Type h
+  _≤_ = Hom
+  
+  reflexive : ∀ {x} → x ≤ x
+  reflexive = id
+
+  transitive : ∀ {x y z} → x ≤ y → y ≤ z → x ≤ z
+  transitive f g = g ∘ f
+```
+
+Any pair of opposing morphisms in a proset (thus in a poset) gives an
+isomorphism. The "inversion" equations hold by thinness: Since $(f \circ
+g) : A \le A$, then it must be equal to `reflexive`{.Agda} above.
+
+```agda
+  antisym : ∀ {x y} → x ≤ y → y ≤ x → x ≡ y
+  antisym f g = isoToPath hasIsUnivalent 
+    (record 
+      { to = f 
+      ; from = g 
+      ; inverses = record 
+        { invˡ = isThin _ _ _ _ ; invʳ = isThin _ _ _ _ } })
+```
+
+Forgetting the univalence datum lets us turn a `Poset`{.Agda} into a
+`Proset`{.Agda}.
+
+```agda
+  →Proset : Proset o h
+  →Proset .Proset.underlying = underlying
+  →Proset .Proset.hasIsThin  = hasIsThin
+```
+
+## Making posets
+
+[Rijke's theorem] says that any type equipped with a reflexive relation
+$x \sim y$ which implies $x \equiv y$ is automatically a set. If $x \le
+y$ is a reflexive, antisymmetric relation, we can take the relation $x
+\sim y = (x \le y) \land (y \le x)$, which is evidently reflexive and,
+by antisymmetry, implies $x \equiv y$.
+
+[Rijke's theorem]: 1Lab.HLevel.Sets.html#rijkes-theorem
+
+```agda
+module _ where
+  open Poset
+
+  makePoset : ∀ {ℓ ℓ'} {A : Type ℓ} {R : A → A → Type ℓ'}
+            → (∀ {x} → R x x)
+            → (∀ {x y z} → R x y → R y z → R x z)
+            → (∀ {x y} → R x y → R y x → x ≡ y)
+            → (∀ {x y} → isProp (R x y))
+            → Poset ℓ ℓ'
+```
+
+Thus, to make a poset, it suffices to have a type $A$ (any old type!), a
+relation on $R$, and witnesses of reflexivity, transitivity, and
+antisymmetry. We derive that $A$ is a set using Rijke's theorem as
+described above, and prove that any antisymmetric proset is univalent.
+
+```agda
+  makePoset {A = A} {R} Rrefl Rtrans Rantisym Rprop = tc where
+    Aset : isSet A
+    Aset = Rijke-isSet {R = λ x y → R x y × R y x} 
+      (Rrefl , Rrefl) 
+      (λ (f , g) → Rantisym f g)
+      λ x y i → Rprop (x .fst) (y .fst) i , Rprop (x .snd) (y .snd) i
+
+    open Proset (makeProset Aset Rrefl Rtrans Rprop)
+      renaming ( underlying to cat ; hasIsThin to ist )
+    open import Cat.Reasoning cat
+
+    tc : Poset _ _
+    tc .underlying = cat
+    tc .hasIsThin  = ist
+```
+
+For the centre of contraction, we take $A$ and the identity isomorphism.
+Then, assume that we have some other object $B$ equipped with an iso $i
+: A \cong B$. Since an iso is a big conjunction of propositional
+components, it's a proposition, so it suffices to show $A \equiv B$. But
+from the iso we have $(A \le B) \land (B \le A)$, and antisymmetry
+finishes the job.
+
+```agda
+    tc .hasIsUnivalent A .centre        = A , idIso
+    tc .hasIsUnivalent A .paths (B , i) = Σ≡Prop isp (Rantisym i.to i.from) where 
+      module i = _≅_ i
+      abstract
+        isp : ∀ x → isProp (A ≅ x)
+        isp ob x y i .to   = Rprop (x .to)   (y .to)   i
+        isp ob x y i .from = Rprop (x .from) (y .from) i
+        isp ob x y i .inverses = 
+          isProp→PathP 
+            (λ i → isProp-Inverses {f = Rprop (x .to)   (y .to)   i} 
+                                   {g = Rprop (x .from) (y .from) i})
+            (x .inverses) (y .inverses) i
+```
+
+## Monotone maps
+
+Rather than considering _functors_ between posets, we can consider
+**monotone maps** between them. This is because, since each hom-set is a
+proposition, the functor identities are automatically satisfied:
+
+```agda
+module _ where
+  open Poset
+
+  Monotone : {C : Poset o h} {D : Poset o′ h′}
+           → (f : C .Ob → D .Ob)
+           → (∀ x y → Hom C x y → Hom D (f x) (f y))
+           → Functor (C .underlying) (D .underlying)
+  Monotone f ord .Functor.F₀ = f
+  Monotone f ord .Functor.F₁ = ord _ _
+  Monotone {D = D} f ord .Functor.F-id = D .isThin _ _ _ _
+  Monotone {D = D} f ord .Functor.F-∘ _ _ = D .isThin _ _ _ _
+
+  open Precategory
+
+  Posets : ∀ o h → Precategory (lsuc (o ⊔ h)) (o ⊔ h)
+  Posets o h .Ob = Poset o h
+  Posets _ _ .Hom x y = Functor (x .underlying) (y .underlying)
+  Posets _ _ .Hom-set _ d = isSet-Functor (d .isStrict)
+  Posets _ _ .id = Id
+  Posets _ _ ._∘_ = _F∘_
+  Posets _ _ .idr f = Functor≡ (λ _ → refl) λ _ → refl
+  Posets _ _ .idl f = Functor≡ (λ _ → refl) λ _ → refl
+  Posets _ _ .assoc f g h = Functor≡ (λ _ → refl) λ _ → refl
+```
+
+# Prosetal reflection
+
+There is an evident functor from $\prosets$ to $\strcat$ given by
+forgetting the thinness data. This functor is ff., since maps between
+prosets are functors between strict categories: it acts on morphisms
+literally by the identity function.
+
+```agda
+Forget : ∀ {o h} → Functor (Prosets o h) (StrictCat o h)
+Forget .F₀ C = Proset.underlying C , Proset.isStrict C
+Forget .F₁ f = f
+Forget .F-id = refl
+Forget .F-∘ _ _ = refl
+```
+
+This functor begs the question: is it possible to freely turn a strict
+category into a proset? The answer is yes! We can [propositionally
+truncate] each of the $\hom$-sets. This provides a reflection of strict
+categories into prosets.
+
+[propositionally truncate]: 1Lab.HIT.Truncation.html
+
+```agda
+Free : ∀ {o h} → Functor (StrictCat o h) (Prosets o h)
+Free .F₀ C = pro where
+  open Precategory
+
+  pro : Proset _ _
+  pro = makeProset {R = λ x y → ∥ C .fst .Hom x y ∥} (C .snd) 
+    (inc (C .fst .id)) 
+    (∥-∥-elim₂ (λ _ _ → squash) λ f g → inc (C .fst ._∘_ g f)) 
+    squash
+```
+
+The `Free`{.Agda} proset functor takes a strict category on the proset
+obtained by truncating each of its hom-sets. This induced relation is
+reflexive (by including the identity map), and transitive (by lifting
+the composition map onto the truncation). On morphisms, it preserves the
+object part, and lifts the morphism action onto the truncations.
+
+```agda
+Free .F₁ F .F₀      = F₀ F
+Free .F₁ F .F₁      = ∥-∥-map (F₁ F)
+Free .F₁ F .F-id i  = inc (F-id F i)
+Free .F₁ F .F-∘ _ _ = squash _ _
+Free .F-id    = Functor≡ (λ _ → refl) λ f → squash _ _
+Free .F-∘ f g = Functor≡ (λ _ → refl) λ f → squash _ _
+```
+
+This `Free`{.Agda} functor is a [left adjoint] to the `Forget`{.Agda}
+functor defined above, so in particular we conclude that it induces an
+idempotent monad on `StrictCat`{.Agda}: The "thinning" of a
+`Proset`{.Agda} is the same proset we started with.
+
+[left adjoint]: Cat.Functor.Adjoint.html
+
+```agda
+Free⊣Forget : Free ⊣ Forget {o} {h}
+Free⊣Forget .unit .η _ .F₀ x = x
+Free⊣Forget .unit .η _ .F₁ = inc
+Free⊣Forget .unit .η _ .F-id = refl
+Free⊣Forget .unit .η _ .F-∘ f g = refl
+Free⊣Forget .unit .is-natural x y f = Functor≡ (λ x → refl) λ _ → refl
+
+Free⊣Forget .counit .η pro .F₀ x = x
+Free⊣Forget .counit .η pro .F₁ = ∥-∥-elim (λ _ → pro .Proset.isThin _ _) λ x → x
+Free⊣Forget .counit .η pro .F-id = refl
+Free⊣Forget .counit .η pro .F-∘ f g = pro .Proset.isThin _ _ _ _
+Free⊣Forget .counit .is-natural x y f = 
+  Functor≡ (λ _ → refl) λ f → y .Proset.isThin _ _ _ _
+
+Free⊣Forget .zig = Functor≡ (λ _ → refl) λ _ → squash _ _
+Free⊣Forget .zag = Functor≡ (λ _ → refl) λ _ → squash _ _
+```
+
+## Poset completions
+
+It's also possible to freely turn a proset into a poset. We do this in a
+separate module: [`Cat.Thin.Completion`](Cat.Thin.Completion.html).

--- a/src/Cat/Thin/Completion.lagda.md
+++ b/src/Cat/Thin/Completion.lagda.md
@@ -1,0 +1,217 @@
+```agda
+open import Cat.Instances.StrictCat
+open import Cat.Instances.Functor
+open import Cat.Functor.Adjoint
+open import Cat.Functor.Base
+open import Cat.Prelude
+open import Cat.Thin
+
+open import Data.Set.Coequaliser
+
+module Cat.Thin.Completion where
+```
+
+<!--
+```agda
+open Functor
+open Proset using (underlying)
+open Poset using (underlying)
+```
+-->
+
+# Poset completion
+
+We construct a universal completion of a `proset`{.Agda} to a
+`poset`{.Agda}. Initially, recall the terms. A proset (which is how we
+refer to strict, thin [categories]) is a set equipped with a relation $-
+\le -$ which is both reflexive and transitive, but not necessarily
+antisymmetric. A poset augments this with the requirement that $\le$ is
+antisymmetric: It's a [_univalent_] thin category.
+
+[categories]: Cat.Base.html
+[_univalent_]: Cat.Univalent.html
+
+The construction is _conceptually_ straightforward: The poset completion
+of $\ca{C}$, written $\widehat{\ca{C}}$, will have an underlying set of
+objects $\widehat{\ca{C}}_0$ given by a quotient of $\ca{C}_0$ by the
+relation $(x \le y) \land (y \le x)$. Essentially, we will forcibly
+"throw in" all of the missing antisymmetries.
+
+[quotient]: Data.Set.Coequaliser.html#quotients
+
+```agda
+module Poset-completion {o h} (C : Proset o h) where
+  module C = Proset C
+
+  private
+    _~_ : C.Ob → C.Ob → Type _
+    x ~ y = C.Hom x y × C.Hom y x
+
+  Ob′ : Type (o ⊔ h)
+  Ob′ = C.Ob / _~_
+```
+
+However, showing that we can lift $\le$ from the proset $\ca{C}$ to its
+completion $\widehat{\ca{C}}$ is much harder than it should be. We start
+by showing that, assuming that $x \le y$ and $y \le x$, we have
+equalities $(x \le a) = (y \le a)$ and $(x \le a) = (y \le a)$. These
+are given by propositional extensionality and pre/post composition with
+the assumed inequalities:
+
+```agda
+  private abstract
+    p1 : (a : C.Ob) ((x , y , r) : Σ[ x ∈ C.Ob ] Σ[ y ∈ C.Ob ] x ~ y) 
+      → Path (Prop h) (C.Hom x a , C.isThin x a) (C.Hom y a , C.isThin y a)
+    p1 a (x , y , f , g) = 
+      Σ≡Prop (λ _ → isProp-isProp) 
+        (ua (propExt (C.isThin _ _) (C.isThin _ _) (λ h → h C.∘ g) (λ h → h C.∘ f)))
+
+    p2 : (a : C.Ob) ((x , y , r) : Σ[ x ∈ C.Ob ] Σ[ y ∈ C.Ob ] x ~ y) 
+      → Path (Prop h) (C.Hom a x , C.isThin a x) (C.Hom a y , C.isThin a y)
+    p2 a (x , y , f , g) = 
+      Σ≡Prop (λ _ → isProp-isProp) 
+        (ua (propExt (C.isThin _ _) (C.isThin _ _) (λ h → f C.∘ h) (λ h → g C.∘ h)))
+```
+
+We can then eliminate from our quotient to the `type of
+propositions`{.Agda}. This is because we're trying to define a type
+which is a proposition, but we can't directly eliminate into
+`Type`{.Agda}, since set-quotients only let you eliminate into sets. By
+the equalities above, the map $x, y \mapsto (x \le y)$ respects the
+quotient, hence `Hom′`{.Agda} below exists:
+
+```agda
+  Hom′ : Ob′ → Ob′ → Prop _
+  Hom′ = Coeq-rec₂ (isHLevel-nType 1) (λ x y → C.Hom x y , C.isThin x y) p1 p2
+
+  Hom′-prop : ∀ (x y : Ob′) (f g : Hom′ x y .fst) → f ≡ g
+  Hom′-prop x y f g = Hom′ x y .snd f g
+```
+
+We can now prove that `Hom′`{.Agda} is `reflexive`{.Agda ident=id′},
+`transitive`{.Agda ident=trans′} and `antisymmetric`{.Agda
+ident=antisym′}. We get these by elimination on the domains/codomains of
+the map:
+
+```agda
+  id′ : ∀ x → Hom′ x x .fst
+  id′ = Coeq-elimProp (λ x → Hom′ x x .snd) (λ _ → C.id)
+
+  trans′ : ∀ x y z → Hom′ x y .fst → Hom′ y z .fst → Hom′ x z .fst
+  trans′ = Coeq-elimProp₃ 
+    (λ x _ z → isHLevel→ 1 (isHLevel→ 1 (Hom′ x z .snd))) 
+    (λ _ _ _ f g → g C.∘ f)
+
+  antisym′ : ∀ x y → Hom′ x y .fst → Hom′ y x .fst → x ≡ y
+  antisym′ = Coeq-elimProp₂ 
+    (λ x y → isHLevel→ 1 (isHLevel→ 1 (squash _ _))) 
+    (λ x y f g → quot (f , g))
+```
+
+The data above cleanly defines a `Poset`{.Agda}, so we're done!
+
+```agda
+  completed : Poset (o ⊔ h) h
+  completed = makePoset {A = Ob′} {R = λ x y → Hom′ x y .fst} 
+      (λ {x} → id′ x) 
+      (λ {x} {y} {z} → trans′ x y z) 
+      (λ {x} {y} → antisym′ x y) 
+      (λ {x} {y} → Hom′ x y .snd)
+
+open Poset-completion 
+  renaming (completed to Poset-completion)
+  hiding (Ob′ ; Hom′ ; Hom′-prop ; trans′ ; antisym′ ; id′)
+```
+
+## Embedding
+
+There is a functor between the underlying category of a proset $\ca{C}$
+and the underlying category of its completion $\widehat{\ca{C}}$, with
+object part given by the quotient map `inc`{.Agda}.
+
+```agda
+Complete : ∀ {o h} {X : Proset o h} 
+         → Functor (X .underlying) (Poset-completion X .underlying)
+Complete .F₀ = inc
+Complete .F₁ x = x
+Complete .F-id = refl
+Complete .F-∘ f g = refl
+```
+
+This functor has morphism part given by the identity function, so it's
+fully faithful. It exhibits $\ca{C}$ as a full subproset of
+$\widehat{\ca{C}}$.
+
+```agda
+Complete-ff : ∀ {o h} {X : Proset o h} → isFf (Complete {X = X})
+Complete-ff = idEquiv
+```
+
+## Lifting functors
+
+We prove that any functor $F : \ca{X} \to \ca{Y}$ lifts to a functor
+$\widehat{F} : \widehat{\ca{X}} \to \widehat{\ca{Y}}$ between the
+respective poset completions. The hardest part of the construction is
+showing that $F_0$, i.e. the action of $F$ on the objects of $\ca{X}$,
+respects the quotient which defines $\widehat{\ca{X}}$.
+
+```agda
+module _ 
+  {o h} (X Y : Proset o h) 
+  (F : Functor (X .underlying) (Y .underlying)) 
+  where
+
+  private
+    module X′ = Poset (Poset-completion X)
+    module Y′ = Poset (Poset-completion Y)
+```
+
+Fortunately, even this is not very hard: It suffices to show that if $x
+< y$ and $y < x$, then $f(x) < f(y)$ and $f(y) < f(x)$. But this is
+immediate by monotonicity of $F$.
+
+```agda
+    F′₀ : X′.Ob → Y′.Ob
+    F′₀ = Coeq-rec Y′.isStrict 
+      (λ x → inc (F₀ F x)) 
+      (λ (_ , _ , f , g) → quot (F₁ F f , F₁ F g))
+```
+
+The rest of the data of a functor is immediate by induction on
+quotients. It's given by lifting the functor data from $F$ to the
+quotient, but it is quite annoying to convince Agda that this is a legal
+move.
+
+```agda
+    F′₁ : (a b : X′.Ob) → X′.Hom a b → Y′.Hom (F′₀ a) (F′₀ b)
+    F′₁ = Coeq-elimProp₂ 
+      (λ a b → isHLevel→ 1 (Y′.isThin (F′₀ a) (F′₀ b))) 
+      (λ _ _ → F₁ F)
+
+    abstract
+      F′₁-id : ∀ (a : X′.Ob) → F′₁ a a (X′.id {a}) ≡ Y′.id {F′₀ a}
+      F′₁-id = Coeq-elimProp 
+        (λ a → Y′.Hom-set (F′₀ a) (F′₀ a) _ _) 
+        (λ a → F-id F)
+
+      F′₁-∘ : ∀ (x y z : X′.Ob) (f : X′.Hom y z) (g : X′.Hom x y)
+            → F′₁ x z (X′._∘_ {x} {y} {z} f g) 
+            ≡ Y′._∘_ {F′₀ x} {F′₀ y} {F′₀ z} (F′₁ y z f) (F′₁ x y g)
+      F′₁-∘ = 
+        Coeq-elimProp₃ 
+          (λ x y z → 
+            isHLevelΠ 1 λ f → 
+            isHLevelΠ 1 λ g → 
+            Y′.Hom-set (F′₀ x) (F′₀ z) _ _) 
+          λ x y z f g → F-∘ F f g
+```
+
+This defines a map between the completions of $\ca{X}$ and $\ca{Y}$:
+
+```agda
+  liftToCompletion : Functor X′.underlying Y′.underlying
+  liftToCompletion .F₀               = F′₀
+  liftToCompletion .F₁   {x} {y}     = F′₁ x y
+  liftToCompletion .F-id {x}         = F′₁-id x
+  liftToCompletion .F-∘  {x} {y} {z} = F′₁-∘ x y z
+```

--- a/src/Cat/Univalent.lagda.md
+++ b/src/Cat/Univalent.lagda.md
@@ -1,5 +1,7 @@
 ```
-open import Cat.Prelude
+open import 1Lab.Prelude hiding (_∘_ ; id)
+open import Cat.Solver
+open import Cat.Base
 
 module Cat.Univalent {o h} (C : Precategory o h) where
 
@@ -9,7 +11,7 @@ open import Cat.Morphism C
 # (Univalent) Categories
 
 In much the same way that a partial order is a preorder where $x \le y
-\and y \le x \to x = y$, a **category** is a precategory where
+\land y \le x \to x = y$, a **category** is a precategory where
 isomorphic objects are identified. This is a generalisation of the
 univalence axiom to arbitrary categories, and, indeed, it's phrased in
 the same way: asking for a canonically defined map to be an equivalence.

--- a/src/Data/Set/Coequaliser.lagda.md
+++ b/src/Data/Set/Coequaliser.lagda.md
@@ -167,13 +167,13 @@ very enlightening --- you can mouse over these links to see their types:
 <!--
 ```agda
 Coeq-elimProp₂ : ∀ {ℓ} {f g : A → B} {f' g' : A' → B'} 
-                  {C : Coeq f g → Coeq f' g' → Type ℓ}
+                   {C : Coeq f g → Coeq f' g' → Type ℓ}
                → (∀ x y → isProp (C x y))
                → (∀ x y → C (inc x) (inc y))
                → ∀ x y → C x y
-Coeq-elimProp₂ cprop f = 
-  Coeq-elimProp (λ x → isHLevelΠ 1 λ _ → cprop _ _) 
-    λ x → Coeq-elimProp (λ y → cprop _ _) (f x)
+Coeq-elimProp₂ prop f = 
+  Coeq-elimProp (λ x → isHLevelΠ 1 λ _ → prop _ _) 
+    λ x → Coeq-elimProp (prop (inc x)) (f x)
 
 Coeq-elimProp₃ : ∀ {ℓ} {f g : A → B} {f' g' : A' → B'} {f'' g'' : A'' → B''}
                    {C : Coeq f g → Coeq f' g' → Coeq f'' g'' → Type ℓ}
@@ -216,7 +216,44 @@ Coeq-rec₂ : ∀ {ℓ} {f g : A → B} {f' g' : A' → B'} {C : Type ℓ}
           → (∀ a x → ci (f x) a ≡ ci (g x) a)
           → (∀ a x → ci a (f' x) ≡ ci a (g' x))
           → Coeq f g → Coeq f' g' → C
-Coeq-rec₂ cset = Coeq-elim₂ (λ _ _ → cset)
+Coeq-rec₂ cset ci r1 r2 (inc x) (inc y) = ci x y
+Coeq-rec₂ cset ci r1 r2 (inc x) (glue y i) = r2 x y i
+Coeq-rec₂ cset ci r1 r2 (inc x) (squash y z p q i j) = cset 
+  (Coeq-rec₂ cset ci r1 r2 (inc x) y) 
+  (Coeq-rec₂ cset ci r1 r2 (inc x) z) 
+  (λ j → Coeq-rec₂ cset ci r1 r2 (inc x) (p j)) 
+  (λ j → Coeq-rec₂ cset ci r1 r2 (inc x) (q j)) 
+  i j
+
+Coeq-rec₂ cset ci r1 r2 (glue x i) (inc x₁) = r1 x₁ x i
+Coeq-rec₂ {f = f} {g} {f'} {g'} cset ci r1 r2 (glue x i) (glue y j) = 
+  isSet→SquareP (λ i j → cset)
+    (λ j → r1 (f' y) x j) 
+    (λ j → r2 (f x) y j) 
+    (λ j → r2 (g x) y j) 
+    (λ j → r1 (g' y) x j) 
+    i j
+
+Coeq-rec₂ {f = f} {g} {f'} {g'} cset ci r1 r2 (glue x i) (squash y z p q j k) = 
+  isHLevel-suc 2 cset 
+    (map (glue x i) y) (map (glue x i) z) 
+    (λ j → map (glue x i) (p j)) 
+    (λ j → map (glue x i) (q j)) 
+    (λ i j → exp i j) (λ i j → exp i j)
+    i j k 
+  where
+    map = Coeq-rec₂ cset ci r1 r2
+    exp : I → I → _
+    exp l m = cset 
+      (map (glue x i) y) (map (glue x i) z) 
+      (λ j → map (glue x i) (p j)) 
+      (λ j → map (glue x i) (q j)) 
+      l m
+
+Coeq-rec₂ cset ci r1 r2 (squash x y p q i j) z =
+  cset (map x z) (map y z) (λ j → map (p j) z) (λ j → map (q j) z) i j
+  where
+    map = Coeq-rec₂ cset ci r1 r2
 ```
 -->
 

--- a/support/web/default.scss
+++ b/support/web/default.scss
@@ -425,6 +425,14 @@ details {
   margin-top: 1em;
   margin-bottom: 1em;
 
+}
+
+details:not(.text) {
+  border-left: 5px solid $cyan-500;
+  padding-left: 1em;
+}
+
+details.text {
   border: 3px solid $cyan-100;
   transition: border 0.3s ease-in-out;
 


### PR DESCRIPTION
# Description

This PR got out of hand. Features:

- "Concrete" limit diagrams (terminal, product, pullback, equaliser) + finitely complete categories
- "Concrete" colimit diagrams (initial, coproduct, pushout, coequaliser)
- Proper limits and colimits over a diagram
- The terminal category, comma categories, universal morphisms imply adjunctions
- Prosets, posets, prosetal reflection, posetal completion (thin categories)