### PR TITLE
chore: fix some broken markdown in Hom

### DIFF
--- a/src/Cat/Functor/Hom.lagda.md
+++ b/src/Cat/Functor/Hom.lagda.md
@@ -151,7 +151,7 @@ is the _same_ data as $P$, just melted into a soup of points.
 The cocone we construct will then glue all those points back together
 into $P$.
 
-[category of elements] Cat.Instances.Elements.html
+[category of elements]: Cat.Instances.Elements.html
 
 This is done by projecting out of $\int P$ into $\ca{C}$ via the
 [canonical projection], and then embedding $\ca{C}$ into the category
@@ -162,7 +162,7 @@ can just use the (contravariant) functorial action of $P$ to take a
 $px : P(X)$ and a $f : Hom(A, X)$ to a $P(A)$. This map is natural
 by functoriality of $P$.
 
-[canonical projection] Cat.Instances.Elements.html#Projection
+[canonical projection]: Cat.Instances.Elements.html#Projection
 
 
 ```agda


### PR DESCRIPTION
# Description

Fixes two broken links on the Hom page.

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [x] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [x] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [x] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely file** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".