### PR TITLE
chore: add helper functions for proving hlevels for implicit arguments

### DIFF
--- a/src/1Lab/HLevel/Retracts.lagda.md
+++ b/src/1Lab/HLevel/Retracts.lagda.md
@@ -173,12 +173,25 @@ homotopy n-type is itself a homotopy n-type.
   → is-hlevel (∀ x y → C x y) n
 Π-is-hlevel² n w = Π-is-hlevel n λ _ → Π-is-hlevel n (w _)
 
+Π-is-hlevel²'
+  : ∀ {a b c} {A : Type a} {B : A → Type b} {C : ∀ a → B a → Type c}
+  → (n : Nat) (Bhl : (x : A) (y : B x) → is-hlevel (C x y) n)
+  → is-hlevel (∀ {x y} → C x y) n
+Π-is-hlevel²' n w = Π-is-hlevel' n λ _ → Π-is-hlevel' n (w _)
+
 Π-is-hlevel³
   : ∀ {a b c d} {A : Type a} {B : A → Type b} {C : ∀ a → B a → Type c}
       {D : ∀ a b → C a b → Type d}
   → (n : Nat) (Bhl : (x : A) (y : B x) (z : C x y) → is-hlevel (D x y z) n)
   → is-hlevel (∀ x y z → D x y z) n
 Π-is-hlevel³ n w = Π-is-hlevel n λ _ → Π-is-hlevel² n (w _)
+
+Π-is-hlevel³'
+  : ∀ {a b c d} {A : Type a} {B : A → Type b} {C : ∀ a → B a → Type c}
+      {D : ∀ a b → C a b → Type d}
+  → (n : Nat) (Bhl : (x : A) (y : B x) (z : C x y) → is-hlevel (D x y z) n)
+  → is-hlevel (∀ {x y z} → D x y z) n
+Π-is-hlevel³' n w = Π-is-hlevel' n λ _ → Π-is-hlevel²' n (w _)
 ```
 -->
 

--- a/src/Cat/Displayed/GenericObject.lagda.md
+++ b/src/Cat/Displayed/GenericObject.lagda.md
@@ -240,7 +240,7 @@ is-gaunt-generic-object-is-prop
   → is-prop (is-gaunt-generic-object gobj)
 is-gaunt-generic-object-is-prop = Iso→is-hlevel 1 eqv $
   Σ-is-hlevel 1 hlevel! λ _ →
-  Π-is-hlevel' 1 λ _ → Π-is-hlevel' 1 λ _ → Π-is-hlevel' 1 λ _ → Π-is-hlevel' 1 λ _ →
+  Π-is-hlevel' 1 λ _ → Π-is-hlevel³' 1 λ _ _ _ →
   Π-is-hlevel 1 λ _ →
   PathP-is-hlevel' 1 (Hom[ _ ]-set _ _) _ _
   where unquoteDecl eqv = declare-record-iso eqv (quote is-gaunt-generic-object)

--- a/src/Cat/Internal/Base.lagda.md
+++ b/src/Cat/Internal/Base.lagda.md
@@ -559,7 +559,7 @@ module _ {ℂ 𝔻 : Internal-cat} {F G : Internal-functor ℂ 𝔻} where
   Internal-nat-set = Iso→is-hlevel 2 nat-eqv $
     Σ-is-hlevel 2 hlevel! $ λ _ →
     Σ-is-hlevel 2 hlevel! $ λ _ →
-    Π-is-hlevel' 2 λ _ → Π-is-hlevel' 2 λ _ →
+    Π-is-hlevel²' 2 λ _ _ →
     Π-is-hlevel 2 λ _ → Π-is-hlevel 2 λ _ →
     PathP-is-hlevel 2 Internal-hom-set
 


### PR DESCRIPTION
# Description

This is to add helper functions for proving the h-levels of functions with implicit arguments. They already seem useful in the library itself. I was struggling between `Π-is-hlevel²'` and `Π-is-hlevel'²`, but then found an instance of `²'` in the library. Feel free to change them to `Π-is-hlevel'²` and `Π-is-hlevel'³` if naming is the only issue.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.