### PR TITLE
Prove more order-theoretic properties of Nat

### DIFF
--- a/src/Data/Nat/Properties.lagda.md
+++ b/src/Data/Nat/Properties.lagda.md
@@ -288,6 +288,20 @@ max-≤r zero zero = 0≤x
 max-≤r zero (suc y) = ≤-refl
 max-≤r (suc x) zero = 0≤x
 max-≤r (suc x) (suc y) = s≤s (max-≤r x y)
+
+max-is-lub : (x y z : Nat) → x ≤ z → y ≤ z → max x y ≤ z
+max-is-lub zero zero z 0≤x 0≤x = 0≤x
+max-is-lub zero (suc y) (suc z) 0≤x (s≤s q) = s≤s q
+max-is-lub (suc x) zero (suc z) (s≤s p) 0≤x = s≤s p
+max-is-lub (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (max-is-lub x y z p q)
+
+max-zerol : (x : Nat) → max 0 x ≡ x
+max-zerol zero = refl
+max-zerol (suc x) = refl
+
+max-zeror : (x : Nat) → max x 0 ≡ x
+max-zeror zero = refl
+max-zeror (suc x) = refl
 ```
 
 ### Minimum
@@ -314,4 +328,16 @@ min-≤r zero zero = 0≤x
 min-≤r zero (suc y) = 0≤x
 min-≤r (suc x) zero = 0≤x
 min-≤r (suc x) (suc y) = s≤s (min-≤r x y)
+
+min-is-glb : (x y z : Nat) → z ≤ x → z ≤ y → z ≤ min x y
+min-is-glb x y zero 0≤x 0≤x = 0≤x
+min-is-glb (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (min-is-glb x y z p q)
+
+min-zerol : (x : Nat) → min 0 x ≡ 0
+min-zerol zero = refl
+min-zerol (suc x) = refl
+
+min-zeror : (x : Nat) → min x 0 ≡ 0
+min-zeror zero = refl
+min-zeror (suc x) = refl
 ```


### PR DESCRIPTION
# Description

1. Prove that `max` and `min` are really join and meet (the universal properties).
2. Prove they interact with the bottom (zero) as expected.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.