### PR TITLE
modify prose: Cat.Functor.Adjoint.Reflective

### DIFF
--- a/src/Cat/Functor/Adjoint/Epireflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Epireflective.lagda.md
@@ -151,7 +151,7 @@ is reflective!
         C.strong-mono-cancell (R.₁ (L.₁ f)) (η x) $
         C.subst-is-strong-mono (unit.is-natural _ _ _) $
         C.strong-mono-∘ (η (R.₀ a)) f
-          (C.invertible→strong-mono (is-reflective→unit-G-is-iso L⊣R reflective))
+          (C.invertible→strong-mono (is-reflective→unit-right-is-iso L⊣R reflective))
           f-strong-mono
 ```
 
@@ -226,7 +226,7 @@ $L \dashv R$ is reflective.
       RL[m]∘RL[e]-invertible =
         C.subst-is-invertible (R.expand (L.expand factors)) $
         R.F-map-invertible $
-        is-reflective→F-unit-is-iso L⊣R reflective
+        is-reflective→left-unit-is-iso L⊣R reflective
 ```
 
 This in turn means that $L(R(e))$ must be a strong mono, as
@@ -282,7 +282,7 @@ itself be invertible, so $m$ is invertible via 2-out-of-3.
       m-invertible : C.is-invertible m
       m-invertible =
         C.invertible-cancelr
-          (is-reflective→unit-G-is-iso L⊣R reflective)
+          (is-reflective→unit-right-is-iso L⊣R reflective)
           (C.subst-is-invertible (sym (unit.is-natural _ _ _)) $
              C.invertible-∘ RL[m]-invertible unit-im-invertible)
 ```
@@ -338,7 +338,7 @@ diagram chase; we will spare the innocent reader the details.
         C.monic-cancell $
         C.subst-is-monic (unit.is-natural _ _ _) $
         C.∘-is-monic
-          (C.invertible→monic (is-reflective→unit-G-is-iso L⊣R reflective))
+          (C.invertible→monic (is-reflective→unit-right-is-iso L⊣R reflective))
           f-mono
 
   factor+mono-unit-invertible→strong-epireflective reflective unit-inv factor {x} =
@@ -361,7 +361,7 @@ diagram chase; we will spare the innocent reader the details.
       RL[m]∘RL[e]-invertible =
         C.subst-is-invertible (R.expand (L.expand factors)) $
         R.F-map-invertible $
-        is-reflective→F-unit-is-iso L⊣R reflective
+        is-reflective→left-unit-is-iso L⊣R reflective
 
       RL[e]-mono : C.is-monic (R.₁ (L.₁ e))
       RL[e]-mono =
@@ -391,7 +391,7 @@ diagram chase; we will spare the innocent reader the details.
       m-invertible : C.is-invertible m
       m-invertible =
         C.invertible-cancelr
-          (is-reflective→unit-G-is-iso L⊣R reflective)
+          (is-reflective→unit-right-is-iso L⊣R reflective)
           (C.subst-is-invertible (sym (unit.is-natural _ _ _)) $
              C.invertible-∘ RL[m]-invertible unit-im-invertible)
 

--- a/src/Cat/Functor/Adjoint/Reflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Reflective.lagda.md
@@ -32,7 +32,7 @@ module Cat.Functor.Adjoint.Reflective where
 private variable
   o o' ℓ ℓ' : Level
   C D : Precategory o ℓ
-  F G : Functor C D
+  L ι : Functor C D
 open Functor
 open _=>_
 open ∫Hom
@@ -42,15 +42,15 @@ open ∫Hom
 # Reflective subcategories
 
 Occasionally, [full subcategory] inclusions (hence [[fully faithful
-functors]] --- like the inclusion of [[abelian groups]] into the category of
-all [[groups]], or the inclusion $\Props \mono \Sets$) participate in an
-adjunction
+functors]], like the inclusion of [[abelian groups]] into the
+category of all [[groups]] or the inclusion $\Props \mono \Sets$)
+participate in an adjunction
 
 [full subcategory]: Cat.Functor.FullSubcategory.html
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-  \mathcal{C} & \mathcal{D}
+  \mathcal{C} & \mathcal{D.}
   \arrow[""{name=0, anchor=center, inner sep=0}, "\iota"', shift right=2, hook, from=1-1, to=1-2]
   \arrow[""{name=1, anchor=center, inner sep=0}, "L"', shift right=2, from=1-2, to=1-1]
   \arrow["\dashv"{anchor=center, rotate=-90}, draw=none, from=1, to=0]
@@ -58,82 +58,83 @@ adjunction
 ~~~
 
 :::{.definition #reflective-subcategory}
-When this is the case, we refer to the [[left adjoint]] functor $L$ as the
-**reflector**, and $\iota$ exhibits $\cC$ as a **reflective
+When this is the case, we refer to the [[left adjoint]] functor $L$ as
+the **reflector**, and $\iota$ exhibits $\cC$ as a **reflective
 subcategory** of $\cD$. Reflective subcategory inclusions are of
-particular importance because they are [[monadic functors]]: They exhibit
-$\cC$ as the category of algebras for an ([[idempotent|idempotent monad]])
-monad on $\cD$.
+particular importance because they are [[monadic functors]]: they
+exhibit $\cC$ as the category of algebras for an
+([[idempotent|idempotent monad]]) monad on $\cD$.
 :::
 
 ```agda
-is-reflective : F ⊣ G → Type _
-is-reflective {G = G} adj = is-fully-faithful G
+is-reflective : L ⊣ ι → Type _
+is-reflective {ι = ι} adj = is-fully-faithful ι
 ```
 
-The first thing we will prove is that the counit map $\eps : FGo \to o$
-of a reflexive subcategory inclusion is invertible. Luckily, we have
-developed enough general theory to make this almost immediate:
+The first thing we will prove is that the counit map $\eps : L\iota o
+\to o$ of a reflexive subcategory inclusion is invertible. Luckily, we
+have developed enough general theory to make this almost immediate:
 
-- $G$ is full, so the counit must be a [[split monomorphism]].
-- $G$ is faithful, so the counit must be a [[epimorphism]].
-- Every morphism that is simultaneously split monic and epic is invertible.
+- $ι$ is full, so the counit must be a [[split monomorphism]].
+- $ι$ is faithful, so the counit must be a [[epimorphism]].
+- Every morphism that is simultaneously split monic and epic is
+  invertible.
 
 ```agda
 module
-  _ {C : Precategory o ℓ} {D : Precategory o' ℓ'} {F : Functor C D} {G : Functor D C}
-    (adj : F ⊣ G) (g-ff : is-reflective adj)
+  _ {C : Precategory o ℓ} {D : Precategory o' ℓ'} {L : Functor C D} {ι : Functor D C}
+    (adj : L ⊣ ι) (ι-ff : is-reflective adj)
   where
   private
     module DD = Cat.Reasoning Cat[ D , D ]
     module C = Cat.Reasoning C
     module D = Cat.Reasoning D
-    module F = Func F
-    module G = Func G
-    module GF = Func (G F∘ F)
-    module FG = Func (F F∘ G)
-    module g-ff {x} {y} = Equiv (_ , g-ff {x} {y})
+    module L = Func L
+    module ι = Func ι
+    module ιL = Func (ι F∘ L)
+    module Lι = Func (L F∘ ι)
+    module ι-ff {x} {y} = Equiv (_ , ι-ff {x} {y})
   open _⊣_ adj
 
   is-reflective→counit-is-invertible : ∀ {o} → D.is-invertible (ε o)
   is-reflective→counit-is-invertible {o} =
     D.split-monic+epic→invertible
-      (right-full→counit-split-monic adj (ff→full {F = G} g-ff))
-      (right-faithful→counit-epic adj (ff→faithful {F = G} g-ff))
+      (right-full→counit-split-monic adj (ff→full {F = ι} ι-ff))
+      (right-faithful→counit-epic adj (ff→faithful {F = ι} ι-ff))
 
 ```
 
 <!--
 ```agda
-  is-reflective→counit-is-iso : ∀ {o} → FG.₀ o D.≅ o
+  is-reflective→counit-is-iso : ∀ {o} → Lι.₀ o D.≅ o
   is-reflective→counit-is-iso {o} = morp where
-    morp : F.₀ (G.₀ o) D.≅ o
+    morp : L.₀ (ι.₀ o) D.≅ o
     morp =
       D.invertible→iso (ε _) $
       D.split-monic+epic→invertible
-        (right-full→counit-split-monic adj (ff→full {F = G} g-ff))
-        (right-faithful→counit-epic adj (ff→faithful {F = G} g-ff))
+        (right-full→counit-split-monic adj (ff→full {F = ι} ι-ff))
+        (right-faithful→counit-epic adj (ff→faithful {F = ι} ι-ff))
 
-  is-reflective→counit-iso : (F F∘ G) ≅ⁿ Id
+  is-reflective→counit-iso : (L F∘ ι) ≅ⁿ Id
   is-reflective→counit-iso = DD.invertible→iso counit invs where
     invs = invertible→invertibleⁿ counit λ x →
       is-reflective→counit-is-invertible
 
-  η-comonad-commute : ∀ {x} → unit.η (G.₀ (F.₀ x)) ≡ G.₁ (F.₁ (unit.η x))
+  η-comonad-commute : ∀ {x} → unit.η (ι.₀ (L.₀ x)) ≡ ι.₁ (L.₁ (unit.η x))
   η-comonad-commute {x} = C.right-inv-unique
-    (F-map-iso G is-reflective→counit-is-iso)
+    (F-map-iso ι is-reflective→counit-is-iso)
     zag
-    (sym (G.F-∘ _ _) ∙ ap G.₁ zig ∙ G.F-id)
+    (sym (ι.F-∘ _ _) ∙ ap ι.₁ zig ∙ ι.F-id)
 
-  is-reflective→unit-G-is-iso : ∀ {o} → C.is-invertible (unit.η (G.₀ o))
-  is-reflective→unit-G-is-iso {o} = C.make-invertible (g-ff.to (ε _))
-    (unit.is-natural _ _ _ ∙∙ ap₂ C._∘_ refl η-comonad-commute ∙∙ GF.annihilate zag)
+  is-reflective→unit-right-is-iso : ∀ {o} → C.is-invertible (unit.η (ι.₀ o))
+  is-reflective→unit-right-is-iso {o} = C.make-invertible (ι-ff.to (ε _))
+    (unit.is-natural _ _ _ ∙∙ ap₂ C._∘_ refl η-comonad-commute ∙∙ ιL.annihilate zag)
     zag
 
-  is-reflective→F-unit-is-iso : ∀ {o} → D.is-invertible (F.₁ (unit.η o))
-  is-reflective→F-unit-is-iso {o} = D.make-invertible
+  is-reflective→left-unit-is-iso : ∀ {o} → D.is-invertible (L.₁ (unit.η o))
+  is-reflective→left-unit-is-iso {o} = D.make-invertible
     (ε _)
-    (sym (counit.is-natural _ _ _) ∙ ap₂ D._∘_ refl (ap F.₁ (sym η-comonad-commute)) ∙ zig)
+    (sym (counit.is-natural _ _ _) ∙ ap₂ D._∘_ refl (ap L.₁ (sym η-comonad-commute)) ∙ zig)
     zig
 ```
 -->
@@ -142,9 +143,9 @@ We can now prove that the adjunction $L \dashv \iota$ is monadic.
 
 ```agda
 is-reflective→is-monadic
-  : ∀ {F : Functor C D} {G : Functor D C}
-  → (adj : F ⊣ G) → is-reflective adj → is-monadic adj
-is-reflective→is-monadic {C = C} {D = D} {F = F} {G} adj g-ff = eqv where
+  : ∀ {L : Functor C D} {ι : Functor D C}
+  → (adj : L ⊣ ι) → is-reflective adj → is-monadic adj
+is-reflective→is-monadic {C = C} {D = D} {L = L} {ι} adj ι-ff = eqv where
 ```
 
 <!--
@@ -152,8 +153,8 @@ is-reflective→is-monadic {C = C} {D = D} {F = F} {G} adj g-ff = eqv where
   module EM = Cat.Reasoning (Eilenberg-Moore (R∘L adj))
   module C = Cat.Reasoning C
   module D = Cat.Reasoning D
-  module F = Functor F
-  module G = Functor G
+  module L = Functor L
+  module ι = Functor ι
   open Algebra-on
   open _⊣_ adj
 
@@ -163,57 +164,57 @@ is-reflective→is-monadic {C = C} {D = D} {F = F} {G} adj g-ff = eqv where
 ```
 -->
 
-It suffices to show that the comparison functor $D \to C^GF$ is fully
-faithful and [[split essentially surjective]]. For full faithfulness,
-observe that it's always faithful; The fullness comes from the
-assumption that $G$ is ff.
+It suffices to show that the comparison functor $D \to C^{\iota L}$ is
+fully faithful and [[split essentially surjective]]. For full
+faithfulness, observe that it's always faithful; The fullness comes from
+the assumption that $\iota$ is ff.
 
 ```agda
   comp-ff : is-fully-faithful Comp
   comp-ff {x} {y} = is-iso→is-equiv λ where
-    .is-iso.from alg → equiv→inverse g-ff (alg .fst)
-    .is-iso.rinv x → ext (equiv→counit g-ff _)
-    .is-iso.linv x → equiv→unit g-ff _
+    .is-iso.from alg → equiv→inverse ι-ff (alg .fst)
+    .is-iso.rinv x → ext (equiv→counit ι-ff _)
+    .is-iso.linv x → equiv→unit ι-ff _
 ```
 
 To show that the comparison functor is split essentially surjective,
 suppose we have an object $o$ admitting the structure of an
-$GF$-algebra; We will show that $o \cong GFo$ as $GF$-algebras --- note
-that $GF(o)$ admits a canonical (free) algebra structure. The algebra
-map $\nu : GF(o) \to o$ provides an algebra morphism from $GF(o) \to o$,
-and the morphism $o \to GF(o)$ is can be taken to be adjunction unit
-$\eta$.
+$\iota L$-algebra; We will show that $o \cong \iota Lo$ as $\iota
+L$-algebras. Note that $\iota L(o)$ admits a canonical (free) algebra
+structure. The algebra map $\nu : \iota L(o) \to o$ provides an algebra
+morphism from $\iota L(o) \to o$ and the morphism $o \to \iota L(o)$ can
+be taken to be adjunction unit $\eta$.
 
 The crucial lemma in establishing that these are inverses is that
-$\eta_{GFx} = GF(\eta_x)$, which follows because both of those morphisms
-are right inverses to $G\eps_x$, which is an isomorphism because $\eps$
-is.
+$\eta_{\iota Lx} = \iota L(\eta_x)$, which follows because both of those
+morphisms are right inverses to $\iota \eps_x$ which is an isomorphism
+because $\eps$ is.
 
 ```agda
   comp-seso : is-split-eso Comp
-  comp-seso (ob , alg) = F.₀ ob , isom where
-    Fo→o : Algebra-hom (R∘L adj) (Comp.₀ (F.₀ ob)) (ob , alg)
-    Fo→o .fst = alg .ν
-    Fo→o .snd = alg .ν-mult
+  comp-seso (ob , alg) = L.₀ ob , isom where
+    Lo→o : Algebra-hom (R∘L adj) (Comp.₀ (L.₀ ob)) (ob , alg)
+    Lo→o .fst = alg .ν
+    Lo→o .snd = alg .ν-mult
 
-    o→Fo : Algebra-hom (R∘L adj) (ob , alg) (Comp.₀ (F.₀ ob))
-    o→Fo .fst = unit.η _
-    o→Fo .snd =
+    o→Lo : Algebra-hom (R∘L adj) (ob , alg) (Comp.₀ (L.₀ ob))
+    o→Lo .fst = unit.η _
+    o→Lo .snd =
         unit.is-natural _ _ _
-      ∙ ap₂ C._∘_ refl (η-comonad-commute adj g-ff)
-      ∙ sym (G.F-∘ _ _)
-      ∙ ap G.₁ (sym (F.F-∘ _ _) ∙∙ ap F.₁ (alg .ν-unit) ∙∙ F.F-id)
-      ∙ sym (ap₂ C._∘_ refl (sym (η-comonad-commute adj g-ff)) ∙ zag ∙ sym G.F-id)
+      ∙ ap₂ C._∘_ refl (η-comonad-commute adj ι-ff)
+      ∙ sym (ι.F-∘ _ _)
+      ∙ ap ι.₁ (sym (L.F-∘ _ _) ∙∙ ap L.₁ (alg .ν-unit) ∙∙ L.F-id)
+      ∙ sym (ap₂ C._∘_ refl (sym (η-comonad-commute adj ι-ff)) ∙ zag ∙ sym ι.F-id)
 
-    isom : Comp.₀ (F.₀ ob) EM.≅ (ob , alg)
-    isom = EM.make-iso Fo→o o→Fo
+    isom : Comp.₀ (L.₀ ob) EM.≅ (ob , alg)
+    isom = EM.make-iso Lo→o o→Lo
       (ext (alg .ν-unit))
       (ext (
           unit.is-natural _ _ _
-        ∙∙ ap₂ C._∘_ refl (η-comonad-commute adj g-ff)
-        ∙∙ sym (G.F-∘ _ _)
-        ∙∙ ap G.₁ (sym (F.F-∘ _ _) ∙∙ ap F.₁ (alg .ν-unit) ∙∙ F.F-id)
-        ∙∙ G.F-id))
+        ∙∙ ap₂ C._∘_ refl (η-comonad-commute adj ι-ff)
+        ∙∙ sym (ι.F-∘ _ _)
+        ∙∙ ap ι.₁ (sym (L.F-∘ _ _) ∙∙ ap L.₁ (alg .ν-unit) ∙∙ L.F-id)
+        ∙∙ ι.F-id))
 
   eqv : is-equivalence Comp
   eqv = ff+split-eso→is-equivalence comp-ff comp-seso
@@ -229,17 +230,17 @@ invertible, then the left adjoint is a reflector.
 ```agda
 module _
   {C : Precategory o ℓ} {D : Precategory o' ℓ'}
-  {F : Functor C D} {G : Functor D C}
-  (adj : F ⊣ G)
+  {L : Functor C D} {R : Functor D C}
+  (adj : L ⊣ R)
   where
   private
     module C = Cat.Reasoning C
     module D = Cat.Reasoning D
     module [D,D] = Cat.Reasoning Cat[ D , D ]
-    module F = Func F
-    module G = Func G
-    module GF = Func (G F∘ F)
-    module FG = Func (F F∘ G)
+    module L = Func L
+    module R = Func R
+    module RL = Func (R F∘ L)
+    module LR = Func (L F∘ R)
     open _⊣_ adj
 ```
 -->
@@ -255,40 +256,42 @@ and thus the corresponding right adjoint must be fully faithful.
 ```agda
   is-counit-iso→is-reflective : is-invertibleⁿ counit → is-reflective adj
   is-counit-iso→is-reflective counit-iso =
-    full+faithful→ff G
-      G-full
-      G-faithful
+    full+faithful→ff R
+      R-full
+      R-faithful
     where
-      G-full : is-full G
-      G-full =
+      R-full : is-full R
+      R-full =
         counit-split-monic→right-full adj $
         D.invertible→to-split-monic $
         is-invertibleⁿ→is-invertible counit-iso _
 
-      G-faithful : is-faithful G
-      G-faithful =
+      R-faithful : is-faithful R
+      R-faithful =
         counit-epic→right-faithful adj $
         D.invertible→epic $
         is-invertibleⁿ→is-invertible counit-iso _
 ```
 
-Furthermore, if we have *any* natural isomorphism $\alpha : FG \iso \Id$, then
-the left adjoint is a reflector! To show this, we will construct an
-inverse to the counit; our previous result will then ensure that $F$
-is fully faithful.
+Furthermore, if we have *any* natural isomorphism $\alpha : LR \iso
+\Id$, then the left adjoint is a reflector! To show this, we will
+construct an inverse to the counit; our previous result will then ensure
+that $F$ is fully faithful.
 
-To begin, recall that isos have the 2-out-of-3 property, so it suffices
-to show that $\eps \circ \alpha$ is invertible. Next, note that we can
-transfer the comonad structure on $FG$ onto a comonad structure on $\Id$
-by repeatedly composing with $\alpha$; this yields a natural transformation
-$\delta : \Id \to \Id$ that is a right inverse to $\eps \circ \alpha$.
+To begin, recall that isos have the 2-out-of-3 property. Thus it
+suffices to show that $\eps \circ \alpha$ is invertible. Next, note that
+we can transfer the comonad structure on $LR$ onto a comonad structure
+on $\Id$ by repeatedly composing with $\alpha$; this yields a natural
+transformation $\delta : \Id \to \Id$ that is a right inverse to $\eps
+\circ \alpha$.
 
-Finally, all natural transformations $\Id \to \Id$ commute with one another,
-so $\delta$ is also a right inverse, and $\eps \circ \alpha$ is invertible.
+Finally, all natural transformations $\Id \to \Id$ commute with one
+another, so $\delta$ is also a right inverse, and $\eps \circ \alpha$ is
+invertible.
 
 ```agda
-  FG-iso→is-reflective : (F F∘ G) ≅ⁿ Id → is-reflective adj
-  FG-iso→is-reflective α =
+  LR-iso→is-reflective : (L F∘ R) ≅ⁿ Id → is-reflective adj
+  LR-iso→is-reflective α =
     is-counit-iso→is-reflective $
     [D,D].invertible-cancell
       ([D,D].iso→invertible (α [D,D].Iso⁻¹))
@@ -297,10 +300,10 @@ so $\delta$ is also a right inverse, and $\eps \circ \alpha$ is invertible.
       module α = Isoⁿ α
 
       δ : Id {C = D} => Id
-      δ .η x = α.to .η x D.∘ α.to .η (F.F₀ (G.₀ x)) D.∘ F.₁ (unit.η (G.₀ x)) D.∘ α.from .η x
+      δ .η x = α.to .η x D.∘ α.to .η (L.₀ (R.₀ x)) D.∘ L.₁ (unit.η (R.₀ x)) D.∘ α.from .η x
       δ .is-natural x y f =
           D.extendr (D.extendr (D.extendr (α.from .is-natural _ _ _)))
-        ∙ D.pushl (D.pushr (D.pushr (F.weave (unit .is-natural _ _ _))))
+        ∙ D.pushl (D.pushr (D.pushr (L.weave (unit .is-natural _ _ _))))
         ∙ D.pushl (D.pushr (α.to .is-natural _ _ _))
         ∙ D.pushl (α.to .is-natural _ _ _)
 
@@ -308,7 +311,7 @@ so $\delta$ is also a right inverse, and $\eps \circ \alpha$ is invertible.
       right-ident = ext λ x →
           D.cancel-inner (α.invr ηₚ _)
         ∙ D.pulll (sym $ α.to .is-natural _ _ _)
-        ∙ D.cancel-inner (F.annihilate zag)
+        ∙ D.cancel-inner (L.annihilate zag)
         ∙ α.invl ηₚ _
 
       right-ident⁻¹ : δ ∘nt (counit ∘nt α.from) ≡ idnt

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -407,7 +407,7 @@ the object. Given a map $a : a \to \iota X$,
       Σ-prop-path! (h≡k factors factors') }
     where
       module rf = D.is-invertible rf-inv
-      module η⁻¹ {a} = C.is-invertible (is-reflective→unit-G-is-iso r⊣ι ι-ff {a})
+      module η⁻¹ {a} = C.is-invertible (is-reflective→unit-right-is-iso r⊣ι ι-ff {a})
 ```
 
 Observe that, since $r \dashv \iota$ is a reflective subcategory, every
@@ -469,7 +469,7 @@ k$.
         rh≡rk : r.₁ h ≡ r.₁ k
         rh≡rk = D.invertible→epic rf-inv (r.₁ h) (r.₁ k) (r.weave (p ∙ sym q))
 
-        h≡k = C.invertible→monic (is-reflective→unit-G-is-iso r⊣ι ι-ff) _ _ $
+        h≡k = C.invertible→monic (is-reflective→unit-right-is-iso r⊣ι ι-ff) _ _ $
           unit.η (ι.₀ X) C.∘ h ≡⟨ unit.is-natural _ _ _ ⟩
           ιr.₁ h C.∘ unit.η B  ≡⟨ ap ι.₁ rh≡rk C.⟩∘⟨refl ⟩
           ιr.₁ k C.∘ unit.η B  ≡˘⟨ unit.is-natural _ _ _ ⟩
@@ -505,5 +505,5 @@ which $\eta$ is an isomorphism.
   in-subcategory→orthogonal-to-ηs inv =
     m⊥-iso C (unit.η _) (C.invertible→iso _ (C.is-invertible-inverse inv))
       (in-subcategory→orthogonal-to-inverted
-        (is-reflective→F-unit-is-iso r⊣ι ι-ff))
+        (is-reflective→left-unit-is-iso r⊣ι ι-ff))
 ```

--- a/src/Elephant.lagda.md
+++ b/src/Elephant.lagda.md
@@ -46,7 +46,7 @@ find possible contributions!]
 
 <!--
 ```agda
-_ = FG-iso→is-reflective
+_ = LR-iso→is-reflective
 _ = crude-monadicity
 _ = ∫
 _ = Karoubi-is-completion
@@ -155,4 +155,3 @@ _ = Sh[]-cc
   * *Reflectivity*: `Sheafification-is-reflective`{.Agda}
   * *Completeness*: `Sh[]-is-complete`{.Agda}
   * *Cocompleteness*: `Sh[]-is-cocomplete`{.Agda}
-  * *Cartesian closure*: `Sh[]-cc`{.Agda}


### PR DESCRIPTION
# Description

This file starts out with a diagram L ⊣ ι, but then begins to use the terms F ⊣ G everywhere. I thought this was a bit confusing, and tried to make the whole file L ⊣ ι. When used in theorem names I explicitly changed to "left" and "right", and at the end of the file (whose assumptions are a general pair of adjoint functors) I changed to the more clear L ⊣ R.

Other changes are `:'<,'>gq` and minor prose adjustments/fixes.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.
