### PR TITLE
refactor: use a refinement type for Data.Vec

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -31,7 +31,7 @@ open import Meta.Alt public
 
 open Data.Product.NAry using ([_]) public
 open Data.List.Base hiding (lookup ; tabulate) public
-open Data.Vec.Base using (Vec ; [] ; _∷_ ; lookup ; tabulate) public
+open Data.Vec.Base hiding (_++_ ; tail ; head; zero; suc; zip; zip-with) public
 open Data.Bool.Base public
 open Data.Dec.Base public
 

--- a/src/1Lab/Reflection/Deriving/Show.agda
+++ b/src/1Lab/Reflection/Deriving/Show.agda
@@ -9,7 +9,7 @@ open import Data.String.Show
 open import Data.String.Base
 open import Data.Char.Base
 open import Data.Fin.Base
-open import Data.Vec.Base hiding (map)
+open import Data.Vec.Base
 open import Data.Nat.Base
 open import Data.Int.Base using (Int ; pos ; negsuc)
 

--- a/src/1Lab/Reflection/List.lagda.md
+++ b/src/1Lab/Reflection/List.lagda.md
@@ -184,12 +184,11 @@ not-member! {not-mem = not-mem} = not-mem
 
 ```agda
 private
-  member-example : true ∈ [ false , true , false , true , false ]
+  member-example : true ∈ [ false , true , false , true , false ]L
   member-example = member!
-
-  not-member-example : true ∉ [ false , false , false ]
+  not-member-example : true ∉ [ false , false , false ]L
   not-member-example = not-member!
 
-  unique-member-example : is-contr (true ∈ [ false , true , false , false ])
+  unique-member-example : is-contr (true ∈ [ false , true , false , false ]L)
   unique-member-example = unique-member!
 ```

--- a/src/1Lab/Reflection/Variables.agda
+++ b/src/1Lab/Reflection/Variables.agda
@@ -81,7 +81,7 @@ private
   env-rec Mot _▷*_ []* (xs ▷ x) = env-rec (Mot ∘ suc) _▷*_ ([]* ▷* x) xs
 
   reverse : Env A n → Vec A n
-  reverse {A = A} env = env-rec (Vec A) (λ xs x → x ∷ xs) [] env
+  reverse {A = A} env = env-rec (Vec A) (λ xs x → x ∷v xs) []v env
 
 
 

--- a/src/Algebra/Ring/Solver.agda
+++ b/src/Algebra/Ring/Solver.agda
@@ -73,7 +73,7 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
   En : ∀ {n} → Normal n → Vec R n → R
 
   Ep ∅ i = R.0r
-  Ep (p *x+ c) (x ∷ e) = Ep p (x ∷ e) R.* x R.+ En c e
+  Ep (p *x+ c) v with (x ∷ e) ← vec-view v = Ep p (x ∷v e) R.* x R.+ En c e
 
   En (con x) i = embed-coe x
   En (poly x) i = Ep x i
@@ -234,12 +234,14 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
   ⟦ x ⟧ₙ ρ = En (normal x) ρ
 
   0n-hom : ∀ {n} (ρ : Vec R n) → En 0n ρ ≡ R.0r
-  0n-hom [] = ℤ↪R.pres-0
-  0n-hom (x ∷ ρ) = refl
+  0n-hom v with vec-view v
+  ... | [] = ℤ↪R.pres-0
+  ... | (x ∷ ρ) = refl
 
   1n-hom : ∀ {n} (ρ : Vec R n) → En 1n ρ ≡ R.1r
-  1n-hom [] = ℤ↪R.pres-id
-  1n-hom (x ∷ ρ) =
+  1n-hom v with vec-view v
+  ... | [] = ℤ↪R.pres-id
+  ... | (x ∷ ρ) =
     (R.0r R.* x) R.+ (En 1n ρ) ≡⟨ R.eliml R.*-zerol ⟩
     En 1n ρ                    ≡⟨ 1n-hom ρ ⟩
     R.1r                       ∎
@@ -247,19 +249,19 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
   *x+ₙ-sound
     : ∀ {n} (p : Poly (suc n)) (c : Normal n) ρ
     → Ep (p *x+ₙ c) ρ ≡ Ep (p *x+ c) ρ
-  *x+ₙ-sound ∅ c (e ∷ ρ) with c ==ₙ 0n
-  ... | just x = sym $
-    Ep (∅ *x+ ⌜ c ⌝) (e ∷ ρ)   ≡⟨ ap! x ⟩
-    Ep (∅ *x+ 0n) (e ∷ ρ)      ≡⟨⟩
+  *x+ₙ-sound ∅ c v with vec-view v | c ==ₙ 0n
+  ... | (e ∷ ρ) | just x = sym $
+    Ep (∅ *x+ ⌜ c ⌝) (e ∷v ρ)   ≡⟨ ap! x ⟩
+    Ep (∅ *x+ 0n) (e ∷v ρ)      ≡⟨⟩
     (R.0r R.* e) R.+ En 0n ρ ≡⟨ R.eliml R.*-zerol ⟩
     En 0n ρ                  ≡⟨ 0n-hom ρ ⟩
     R.0r                               ∎
-  ... | nothing = refl
+  ... | (e ∷ ρ) | nothing = refl
   *x+ₙ-sound (p *x+ x) c ρ = refl
 
   ∅*x+ₙ-hom
     : ∀ {n} (c : Normal n) x ρ
-    → Ep (∅ *x+ₙ c) (x ∷ ρ) ≡ En c ρ
+    → Ep (∅ *x+ₙ c) (x ∷v ρ) ≡ En c ρ
   ∅*x+ₙ-hom c x ρ with c ==ₙ 0n
   ... | just x = sym (ap (λ c → En c ρ) x ∙ 0n-hom ρ)
   ... | nothing = R.eliml R.*-zerol
@@ -273,48 +275,48 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
 
   +ₚ-hom ∅ q ρ = sym R.+-idl
   +ₚ-hom (p *x+ x) ∅ ρ = sym R.+-idr
-  +ₚ-hom (p *x+ c) (q *x+ d) (x ∷ ρ) =
-    Ep ((p +ₚ q) *x+ₙ (c +ₙ d)) (x ∷ ρ)                                 ≡⟨ *x+ₙ-sound (p +ₚ q) (c +ₙ d) (x ∷ ρ) ⟩
-    Ep ((p +ₚ q) *x+ (c +ₙ d)) (x ∷ ρ)                                  ≡⟨⟩
-    ⌜ Ep (p +ₚ q) (x ∷ ρ) ⌝ R.* x R.+ En (c +ₙ d) ρ                     ≡⟨ ap! (+ₚ-hom p q (x ∷ ρ)) ⟩
-    (Ep p (x ∷ ρ) R.+ Ep q (x ∷ ρ)) R.* x R.+ ⌜ En (c +ₙ d) ρ ⌝         ≡⟨ ap! (+ₙ-hom c d ρ) ⟩
-    ⌜ (Ep p (x ∷ ρ) R.+ Ep q (x ∷ ρ)) R.* x ⌝ R.+ (En c ρ R.+ En d ρ)   ≡⟨ ap! R.*-distribr  ⟩
-    Ep p (x ∷ ρ) R.* x R.+ Ep q (x ∷ ρ) R.* x R.+ (En c ρ R.+ En d ρ)   ≡⟨ R.a.pullr (R.pulll R.+-commutes) ⟩
-    Ep p (x ∷ ρ) R.* x R.+ (En c ρ R.+ Ep q (x ∷ ρ) R.* x R.+ En d ρ)   ≡⟨ R.a.extendl (R.a.pulll refl) ⟩
-    Ep p (x ∷ ρ) R.* x R.+ En c ρ R.+ (Ep q (x ∷ ρ) R.* x R.+ En d ρ)   ∎
+  +ₚ-hom (p *x+ c) (q *x+ d) v with (x ∷ ρ) ← vec-view v =
+    Ep ((p +ₚ q) *x+ₙ (c +ₙ d)) (x ∷v ρ)                                ≡⟨ *x+ₙ-sound (p +ₚ q) (c +ₙ d) (x ∷v ρ) ⟩
+    Ep ((p +ₚ q) *x+ (c +ₙ d)) (x ∷v ρ)                                 ≡⟨⟩
+    ⌜ Ep (p +ₚ q) (x ∷v ρ) ⌝ R.* x R.+ En (c +ₙ d) ρ                    ≡⟨ ap! (+ₚ-hom p q (x ∷v ρ)) ⟩
+    (Ep p (x ∷v ρ) R.+ Ep q (x ∷v ρ)) R.* x R.+ ⌜ En (c +ₙ d) ρ ⌝       ≡⟨ ap! (+ₙ-hom c d ρ) ⟩
+    ⌜ (Ep p (x ∷v ρ) R.+ Ep q (x ∷v ρ)) R.* x ⌝ R.+ (En c ρ R.+ En d ρ) ≡⟨ ap! R.*-distribr  ⟩
+    Ep p (x ∷v ρ) R.* x R.+ Ep q (x ∷v ρ) R.* x R.+ (En c ρ R.+ En d ρ) ≡⟨ R.a.pullr (R.pulll R.+-commutes) ⟩
+    Ep p (x ∷v ρ) R.* x R.+ (En c ρ R.+ Ep q (x ∷v ρ) R.* x R.+ En d ρ) ≡⟨ R.a.extendl (R.a.pulll refl) ⟩
+    Ep p (x ∷v ρ) R.* x R.+ En c ρ R.+ (Ep q (x ∷v ρ) R.* x R.+ En d ρ) ∎
   +ₙ-hom (con x)  (con y)  ρ = ℤ↪R.pres-+ (lift x) (lift y)
   +ₙ-hom (poly p) (poly q) ρ = +ₚ-hom p q ρ
 
   *x+-hom
     : ∀ {n} (p q : Poly (suc n)) x ρ
-    → Ep (p *x+ₚ q) (x ∷ ρ)
-    ≡ Ep p (x ∷ ρ) R.* x R.+ Ep q (x ∷ ρ)
+    → Ep (p *x+ₚ q) (x ∷v ρ)
+    ≡ Ep p (x ∷v ρ) R.* x R.+ Ep q (x ∷v ρ)
   *x+-hom ∅ ∅ x ρ = R.introl R.*-zerol
   *x+-hom (p *x+ c) ∅ x ρ = ap₂ R._+_ refl (0n-hom ρ)
   *x+-hom p (q *x+ d) x ρ =
-    Ep (p *x+ₚ (q *x+ d)) (x ∷ ρ)                          ≡⟨⟩
-    Ep ((p +ₚ q) *x+ₙ d) (x ∷ ρ)                           ≡⟨ *x+ₙ-sound (p +ₚ q) d (x ∷ ρ) ⟩
-    ⌜ Ep (p +ₚ q) (x ∷ ρ) ⌝ R.* x R.+ En d ρ               ≡⟨ ap! (+ₚ-hom p q (x ∷ ρ)) ⟩
-    ⌜ (Ep p (x ∷ ρ) R.+ Ep q (x ∷ ρ)) R.* x ⌝ R.+ En d ρ   ≡⟨ ap! R.*-distribr ⟩
-    Ep p (x ∷ ρ) R.* x R.+ Ep q (x ∷ ρ) R.* x R.+ En d ρ   ≡⟨ R.pullr refl ⟩
-    Ep p (x ∷ ρ) R.* x R.+ (Ep q (x ∷ ρ) R.* x R.+ En d ρ) ∎
+    Ep (p *x+ₚ (q *x+ d)) (x ∷v ρ)                           ≡⟨⟩
+    Ep ((p +ₚ q) *x+ₙ d) (x ∷v ρ)                            ≡⟨ *x+ₙ-sound (p +ₚ q) d (x ∷v ρ) ⟩
+    ⌜ Ep (p +ₚ q) (x ∷v ρ) ⌝ R.* x R.+ En d ρ                ≡⟨ ap! (+ₚ-hom p q (x ∷v ρ)) ⟩
+    ⌜ (Ep p (x ∷v ρ) R.+ Ep q (x ∷v ρ)) R.* x ⌝ R.+ En d ρ   ≡⟨ ap! R.*-distribr ⟩
+    Ep p (x ∷v ρ) R.* x R.+ Ep q (x ∷v ρ) R.* x R.+ En d ρ   ≡⟨ R.pullr refl ⟩
+    Ep p (x ∷v ρ) R.* x R.+ (Ep q (x ∷v ρ) R.* x R.+ En d ρ) ∎
 
   *ₙₚ-hom
     : ∀ {n} (c : Normal n) (p : Poly (suc n)) x ρ
-    → Ep (c *ₙₚ p) (x ∷ ρ) ≡ En c ρ R.* Ep p (x ∷ ρ)
+    → Ep (c *ₙₚ p) (x ∷v ρ) ≡ En c ρ R.* Ep p (x ∷v ρ)
   *ₚₙ-hom
     : ∀ {n} (c : Normal n) (p : Poly (suc n)) x ρ
-    → Ep (p *ₚₙ c) (x ∷ ρ) ≡ Ep p (x ∷ ρ) R.* En c ρ
+    → Ep (p *ₚₙ c) (x ∷v ρ) ≡ Ep p (x ∷v ρ) R.* En c ρ
   *ₙ-hom : ∀ {n} (c d : Normal n) ρ → En (c *ₙ d) ρ ≡ En c ρ R.* En d ρ
   *ₚ-hom : ∀ {n} (p q : Poly (suc n)) ρ → Ep (p *ₚ q) ρ ≡ Ep p ρ R.* Ep q ρ
 
   *ₚ-hom ∅ q ρ = sym R.*-zerol
   *ₚ-hom (p *x+ c) ∅ ρ = sym R.*-zeror
-  *ₚ-hom (p *x+ c) (q *x+ d) (x ∷ ρ) =
-      *x+ₙ-sound ((p *ₚ q) *x+ₚ ((p *ₚₙ d) +ₚ (c *ₙₚ q))) _ (x ∷ ρ)
+  *ₚ-hom (p *x+ c) (q *x+ d) v with (x ∷ ρ) ← vec-view v =
+      *x+ₙ-sound ((p *ₚ q) *x+ₚ ((p *ₚₙ d) +ₚ (c *ₙₚ q))) _ (x ∷v ρ)
     ∙ ap₂ R._+_ (ap₂ R._*_ (*x+-hom (p *ₚ q) ((p *ₚₙ d) +ₚ (c *ₙₚ q)) x ρ) refl) refl
-    ∙ ap₂ R._+_ (ap₂ R._*_ (ap₂ R._+_ (ap (R._* x) (*ₚ-hom p q (x ∷ ρ)))
-        (+ₚ-hom (p *ₚₙ d) (c *ₙₚ q) (x ∷ ρ))) refl
+    ∙ ap₂ R._+_ (ap₂ R._*_ (ap₂ R._+_ (ap (R._* x) (*ₚ-hom p q (x ∷v ρ)))
+        (+ₚ-hom (p *ₚₙ d) (c *ₙₚ q) (x ∷v ρ))) refl
         ∙ ap₂ R._*_ (ap₂ R._+_ refl (ap₂ R._+_ (*ₚₙ-hom d p x ρ) (*ₙₚ-hom c q x ρ)))
         refl) refl
     ∙ ap₂ R._+_ refl (*ₙ-hom c d ρ) ∙ lemma _ _ _ _ _
@@ -372,8 +374,8 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
   -ₚ-hom : ∀ {n} (p : Poly (suc n)) ρ → Ep (-ₚ p) ρ ≡ R.- Ep p ρ
   -ₙ-hom : ∀ {n} (n : Normal n) ρ → En (-ₙ n) ρ ≡ R.- En n ρ
 
-  -ₚ-hom p (x ∷ ρ) =
-      *ₙₚ-hom (-ₙ 1n) p x ρ
+  -ₚ-hom p v with (x ∷ ρ) ← vec-view v =
+    *ₙₚ-hom (-ₙ 1n) p x ρ
     ∙ ap₂ R._*_ (-ₙ-hom 1n ρ ∙ ap R.-_ (1n-hom ρ)) refl
     ∙ R.*-negatel ∙ ap R.-_ R.*-idl
   -ₙ-hom (con x) ρ = ℤ↪R.pres-neg {x = lift x}
@@ -381,17 +383,18 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
 
   sound-coe
     : ∀ {n} (c : Int) (ρ : Vec R n) → En (normal-coe c) ρ ≡ embed-coe c
-  sound-coe c [] = refl
-  sound-coe c (x ∷ ρ) = ∅*x+ₙ-hom (normal-coe c) x ρ ∙ sound-coe c ρ
+  sound-coe c v with vec-view v
+  ... | [] = refl
+  ... | (x ∷ ρ) = ∅*x+ₙ-hom (normal-coe c) x ρ ∙ sound-coe c ρ
 
   sound-var : ∀ {n} (j : Fin n) ρ → En (normal-var j) ρ ≡ lookup ρ j
-  sound-var i _ with fin-view i
-  sound-var _ (x ∷ ρ) | zero =
-    Ep (∅ *x+ 1n) (x ∷ ρ) R.* x R.+ En 0n ρ ≡⟨ R.elimr (0n-hom ρ) ⟩
-    ⌜ Ep (∅ *x+ 1n) (x ∷ ρ) ⌝ R.* x         ≡⟨ ap! (R.eliml R.*-zerol ∙ 1n-hom ρ) ⟩
-    R.1r R.* x                              ≡⟨ R.*-idl ⟩
-    x                                       ∎
-  sound-var _ (x ∷ ρ) | suc j = ∅*x+ₙ-hom (normal-var j) x ρ ∙ sound-var j ρ
+  sound-var i v with vec-view v | fin-view i
+  ... | (x ∷ ρ) | zero =
+    Ep (∅ *x+ 1n) (x ∷v ρ) R.* x R.+ En 0n ρ ≡⟨ R.elimr (0n-hom ρ) ⟩
+    ⌜ Ep (∅ *x+ 1n) (x ∷v ρ) ⌝ R.* x         ≡⟨ ap! (R.eliml R.*-zerol ∙ 1n-hom ρ) ⟩
+    R.1r R.* x                               ≡⟨ R.*-idl ⟩
+    x                                        ∎
+  ... | (x ∷ ρ) | suc j = ∅*x+ₙ-hom (normal-var j) x ρ ∙ sound-var j ρ
 
   sound : ∀ {n} (p : Polynomial n) ρ → En (normal p) ρ ≡ ⟦ p ⟧ ρ
   sound (op [+] p q) ρ = +ₙ-hom (normal p) (normal q) ρ ∙ ap₂ R._+_ (sound p ρ) (sound q ρ)
@@ -411,11 +414,11 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
   private
     test-distrib : ∀ x y z → x R.* (y R.+ z) ≡ y R.* x R.+ z R.* x
     test-distrib x y z =
-      solve (var 0 :* (var 1 :+ var 2)) ((var 1 :* var 0) :+ (var 2 :* var 0)) (x ∷ y ∷ z ∷ []) refl
+      solve (var 0 :* (var 1 :+ var 2)) ((var 1 :* var 0) :+ (var 2 :* var 0)) ([ x , y , z ]) refl
 
     test-identities : ∀ x → x R.+ (R.0r R.* R.1r) ≡ (R.1r R.+ R.0r) R.* x
     test-identities x =
-      solve (var 0 :+ (con 0 :* con 1)) ((con 1 :+ con 0) :* var 0) (x ∷ []) refl
+      solve (var 0 :+ (con 0 :* con 1)) ((con 1 :+ con 0) :* var 0) [ x ] refl
 
 module Explicit {ℓ} (R : CRing ℓ) where
   private module I = Impl (R .snd)

--- a/src/Cat/Instances/Assemblies.lagda.md
+++ b/src/Cat/Instances/Assemblies.lagda.md
@@ -330,7 +330,7 @@ x$ is that $e$ is defined, and assemblies are defined so that if $e
   extend {X = X} f = to-assembly-hom record where
     map x     = f x
     realiser  = val ⟨ x ⟩ x
-    tracks ha = subst ⌞_⌟ (sym (abs-β _ [] (_ , X .def ha))) (X .def ha)
+    tracks ha = subst ⌞_⌟ (sym (abs-β _ []v (_ , X .def ha))) (X .def ha)
 ```
 
 <details>

--- a/src/Cat/Instances/Assemblies/Exponentials.lagda.md
+++ b/src/Cat/Instances/Assemblies/Exponentials.lagda.md
@@ -8,7 +8,7 @@ open import Cat.Prelude
 
 open import Data.Partial.Total
 open import Data.Partial.Base
-open import Data.Vec.Base using ([] ; _∷_)
+open import Data.Vec.Base using ([]v ; _∷v_)
 
 open import Realisability.PCA
 
@@ -93,7 +93,7 @@ asm-ev {X = X} {Y = Y} = to-assembly-hom record where
   realiser = val ⟨ u ⟩ `fst `· u `· (`snd `· u)
 
   tracks {a = x} = elim! λ p q α pp p⊩f q⊩a → subst⊩ Y (p⊩f _ _ q⊩a) $
-    (val ⟨ u ⟩ `fst `· u `· (`snd `· u)) ⋆ x           ≡⟨ abs-β _ [] (_ , subst ⌞_⌟ (sym α) (`pair↓₂ pp (X .def q⊩a))) ⟩
+    (val ⟨ u ⟩ `fst `· u `· (`snd `· u)) ⋆ x           ≡⟨ abs-β _ []v (_ , subst ⌞_⌟ (sym α) (`pair↓₂ pp (X .def q⊩a))) ⟩
     `fst ⋆ ⌜ x ⌝ ⋆ (`snd ⋆ ⌜ x ⌝)                      ≡⟨ ap! α ⟩
     `fst ⋆ (`pair ⋆ p ⋆ q) ⋆ (`snd ⋆ (`pair ⋆ p ⋆ q))  ≡⟨ ap₂ _%_ (`fst-β pp (X .def q⊩a)) (`snd-β pp (X .def q⊩a)) ⟩
     p ⋆ q                                              ∎
@@ -120,7 +120,7 @@ curry-asm {X = X} {Y = Y} {Z = Z} h .map x = record where
       realiser = val ⟨ v ⟩ `h `· (`pair `· const (u , X .def u⊩x) `· v)
 
       tracks a⊩x = subst⊩ Z (t (inc (u , _ , refl , u⊩x , a⊩x))) $
-        abs-β _ [] (_ , Y .def a⊩x)
+        abs-β _ []v (_ , Y .def a⊩x)
 ```
 -->
 
@@ -137,9 +137,9 @@ curry-asm {X = X} {Y = Y} {Z = Z} h .tracked = do
     realiser = val ⟨ u ⟩ ⟨ v ⟩ `h `· (`pair `· u `· v)
 
     tracks a⊩x = record where
-      fst = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , X .def a⊩x) ∷ []))) (abs↓ _ _)
+      fst = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , X .def a⊩x) ∷v []v))) (abs↓ _ _)
       snd = inc λ y b b⊩y → subst⊩ Z (t (inc (_ , _ , refl , a⊩x , b⊩y))) $
-        abs-βₙ [] ((b , Y .def b⊩y) ∷ (_ , X .def a⊩x) ∷ [])
+        abs-βₙ []v ((b , Y .def b⊩y) ∷v (_ , X .def a⊩x) ∷v []v)
 ```
 
 <details>

--- a/src/Cat/Instances/Assemblies/Limits.lagda.md
+++ b/src/Cat/Instances/Assemblies/Limits.lagda.md
@@ -10,7 +10,7 @@ open import Cat.Prelude
 
 open import Data.Partial.Total
 open import Data.Partial.Base
-open import Data.Vec.Base using ([] ; _∷_)
+open import Data.Vec.Base using ([]v ; _∷v_)
 
 open import Realisability.PCA
 
@@ -156,7 +156,7 @@ tracked by the constant function with value $\sf{x}$.
 !Asm {X = X} = to-assembly-hom record where
   map    _  = lift tt
   realiser  = val ⟨ x ⟩ x
-  tracks ha = subst ⌞_⌟ (sym (abs-β _ [] (_ , X .def ha))) (X .def ha)
+  tracks ha = subst ⌞_⌟ (sym (abs-β _ []v (_ , X .def ha))) (X .def ha)
 ```
 
 <!--
@@ -191,7 +191,7 @@ Assemblies-equalisers f g .apex = Equ-asm f g
 Assemblies-equalisers {a = A} f g .equ = to-assembly-hom record where
   map (x , _) = x
   realiser    = val ⟨ x ⟩ x
-  tracks ha   = subst⊩ A ha (abs-β _ [] (_ , A .def ha))
+  tracks ha   = subst⊩ A ha (abs-β _ []v (_ , A .def ha))
 Assemblies-equalisers f g .has-is-eq .equal = ext λ x p → p
 ```
 

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -9,6 +9,7 @@ open import Data.Maybe.Base
 open import Data.Bool.Base
 open import Data.Dec.Base
 open import Data.Fin.Base
+open import Data.Irr
 
 open import Meta.Traversable
 open import Meta.Foldable
@@ -16,6 +17,8 @@ open import Meta.Append
 open import Meta.Idiom
 open import Meta.Bind
 open import Meta.Alt
+
+import Data.Nat.Base as Nat
 ```
 -->
 
@@ -35,7 +38,7 @@ operations on lists. Properties of these operations are in the module
 ```agda
 private variable
   ℓ : Level
-  A B : Type ℓ
+  A B C : Type ℓ
 
 infixr 20 _∷_
 ```
@@ -61,6 +64,9 @@ instance
     go zero xs                = []
     go (suc zero) xs          = xs ∷ []
     go (suc (suc n)) (x , xs) = x ∷ go (suc n) xs
+
+[_]L : ∀ {ℓ} {A : Type ℓ} {n} → Vecₓ A n → List A
+[ p ]L = [ p ]
 
 -- Test:
 _ : Path (List Nat) [ 1 , 2 , 3 ] (1 ∷ 2 ∷ 3 ∷ [])
@@ -246,10 +252,13 @@ intercalate x []           = []
 intercalate x (y ∷ [])     = y ∷ []
 intercalate x (y ∷ z ∷ xs) = y ∷ x ∷ intercalate x (z ∷ xs)
 
-zip : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → List A → List B → List (A × B)
-zip [] _ = []
-zip _ [] = []
-zip (a ∷ as) (b ∷ bs) = (a , b) ∷ zip as bs
+zip-with : (A → B → C) → List A → List B → List C
+zip-with f [] _ = []
+zip-with f (_ ∷ _) [] = []
+zip-with f (a ∷ as) (b ∷ bs) = (f a b) ∷ zip-with f as bs
+
+zip : List A → List B → List (A × B)
+zip =  zip-with _,_
 
 unzip : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → List (A × B) → List A × List B
 unzip [] = [] , []
@@ -335,10 +344,18 @@ lookup x ((k , v) ∷ xs) with x ≡? k
 ... | yes _ = just v
 ... | no  _ = lookup x xs
 
+_!?_ : List A → Nat → Maybe A
+[] !? n = nothing
+(x ∷ xs) !? zero = just x
+(x ∷ xs) !? suc n = xs !? n
+
+!?-just : ∀ (xs : List A) (n : Nat) → n Nat.< length xs → is-just (xs !? n)
+!?-just {A = a} (x ∷ xs) zero n<xs = lift oh
+!?-just {A = a} (x ∷ xs) (suc n) n<xs = !?-just xs n (Nat.≤-peel n<xs)
+
 _!_ : (l : List A) → Fin (length l) → A
-(x ∷ xs) ! n with fin-view n
-... | zero  = x
-... | suc i = xs ! i
+xs ! fin n ⦃ pf ⦄ = from-just! _ $ !?-just xs n pf
+
 
 tabulate : ∀ {n} (f : Fin n → A) → List A
 tabulate {n = zero}  f = []

--- a/src/Data/List/Length.agda
+++ b/src/Data/List/Length.agda
@@ -1,0 +1,76 @@
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Data.Maybe.Base
+open import Data.List.Base
+open import Data.Dec.Base
+open import Data.Fin.Base
+open import Data.Nat.Base as Nat
+open import Data.Id.Base
+open import Data.Irr
+
+open import Meta.Idiom
+
+module Data.List.Length where
+
+private variable
+  ℓ : Level
+  A B C : Type ℓ
+  xs ys : List A
+  n k : Nat
+
+data Length {ℓ} {A : Type ℓ} : List A → Nat → Type ℓ where
+  zero : Length [] zero
+  suc  : ∀ {x xs n} → Length xs n → Length (x ∷ xs) (suc n)
+
+instance
+  Length-zero : Length {A = A} [] zero
+  Length-zero = zero
+
+  Length-suc : ∀ {x} → ⦃ Length xs n ⦄ → Length (x ∷ xs) (suc n)
+  Length-suc ⦃ l ⦄ = suc l
+
+  Length-length : ∀ {xs : List A} → Length xs (length xs)
+  Length-length {xs = []} = zero
+  Length-length {xs = x ∷ xs} = suc Length-length
+  {-# INCOHERENT Length-length #-}
+
+  Length-dec : ∀ {xs : List A} → Dec (Length xs n)
+  Length-dec {n = zero} {xs = []} =  yes $ Length-zero
+  Length-dec {n = suc n} {xs = x ∷ xs} =  caseᵈ Length xs n of λ where
+    (yes l) → yes $ Length-suc ⦃ l ⦄
+    (no ¬l) → no λ { (suc l) → ¬l l }
+  Length-dec {n = suc n} {xs = []} = no λ ()
+  Length-dec {n = zero} {xs = x ∷ xs} = no λ ()
+
+
+len-uncons : ∀ {xs n x} → Length {A = A} (x ∷ xs) (suc n) → Length xs n
+len-uncons (suc l) = l
+
+has-lengthᵢ : ∀ {xs : List A} {n : Nat} → Length xs n → length xs ≡ᵢ n
+has-lengthᵢ {xs = []} {n = zero} len = reflᵢ
+has-lengthᵢ {xs = x ∷ xs} {n = suc n} len = apᵢ suc $ has-lengthᵢ $ len-uncons len
+
+has-length : ∀ {xs : List A} {n : Nat} → Irr (Length xs n) → length xs ≡ n
+has-length l = Id≃path.to $ has-lengthᵢ (recover l)
+
+len-++ : Length xs n → Length ys k → Length (xs ++ ys) (n + k)
+len-++ zero l' = l'
+len-++ (suc l) l' = Length-suc ⦃ len-++ l l' ⦄
+
+len-tabulate : ∀ {n} → (v : Fin n → A) → Length (tabulate v) n
+len-tabulate {n = zero} v = zero
+len-tabulate {n = suc _} v = suc (len-tabulate $ v ∘ fsuc)
+
+len-map : ∀ {f : A → B} → Length xs n → Length (f <$> xs) n
+len-map {xs = []} {n = zero} _ = zero
+len-map {xs = x ∷ xs} {n = suc n} (suc l) = suc $ len-map l
+
+len-zip-with
+  : {f : A → B → C} → Length xs n → Length ys n → Length (zip-with f xs ys) n
+len-zip-with {xs = []} zero _ = zero
+len-zip-with {xs = _ ∷ _} {ys = []} _ zero =  zero 
+len-zip-with {xs = x ∷ xs} {ys =  x₁ ∷ ys} (suc l) (suc l') = suc $ len-zip-with l l'
+
+len-zip : Length xs n → Length ys n → Length (zip xs ys) n
+len-zip = len-zip-with

--- a/src/Data/List/Sigma.agda
+++ b/src/Data/List/Sigma.agda
@@ -49,11 +49,11 @@ module _ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} where
       p b q q'
 
     rem₁ : ∀ {x a} (ys : ∀ a → List (B a)) (b : B _) (p : a ≡ᵢ x) → fibre' (ys x) p b → fibreᵢ (ys a !_) b
-    rem₁ {x = x} {a} ys b p (fin ix ⦃ q ⦄ , r) = fin ix ⦃ q' ⦄ , Equiv.to (rem₀ ys b p ix) r where
+    rem₁ {x = x} {a} ys b p (fin ix ⦃ q ⦄ , r) = fin ix ⦃ q' ⦄ , Equiv.to (rem₀ ys b p ix {q} {q'} ) r where
       q' = transport (λ i → suc ix Nat.≤ length (ys (Id≃path.to p (~ i)))) q
 
     rem₂ : ∀ {x a} (ys : ∀ a → List (B a)) (b : B _) (p : a ≡ᵢ x) → fibreᵢ (ys a !_) b → fibre' (ys x) p b
-    rem₂ {x = x} {a} ys b p (fin ix ⦃ q ⦄ , r) = fin ix ⦃ q' ⦄ , Equiv.from (rem₀ ys b p ix) r where
+    rem₂ {x = x} {a} ys b p (fin ix ⦃ q ⦄ , r) = fin ix ⦃ q' ⦄ , Equiv.from (rem₀ ys b p ix {q'} {q}) r where
       q' = transport (λ i → suc ix Nat.≤ length (ys (Id≃path.to p i))) q
 
   sigma-member : ∀ {a b xs ys} → a ∈ₗ xs → b ∈ₗ ys a → (a , b) ∈ₗ sigma xs ys

--- a/src/Data/Maybe/Base.lagda.md
+++ b/src/Data/Maybe/Base.lagda.md
@@ -4,6 +4,7 @@ open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
+open import Data.Bool.Base
 open import Data.Dec.Base
 
 open import Meta.Traversable
@@ -83,19 +84,27 @@ from-just def nothing = def
 
 <!--
 ```agda
-is-just : Maybe A → Type
-is-just (just _) = ⊤
-is-just nothing = ⊥
+is-just? : Maybe A → Bool
+is-just? nothing = false
+is-just? (just _) = true
 
-is-nothing : Maybe A → Type
-is-nothing (just _) = ⊥
-is-nothing nothing = ⊤
+record is-just (m : Maybe A) : Type where
+  constructor lift
+  field
+    lower : So (is-just? m)
 
-nothing≠just : {x : A} → ¬ (nothing ≡ just x)
-nothing≠just p = subst is-nothing p tt
+
+from-just! : ∀ x → is-just x → A
+from-just! (just x) _ = x
 
 just≠nothing : {x : A} → ¬ (just x ≡ nothing)
-just≠nothing p = subst is-just p tt
+just≠nothing p = subst is-just' p tt  where
+  is-just' : Maybe A → Type
+  is-just' (just _) = ⊤
+  is-just' nothing = ⊥
+
+nothing≠just : {x : A} → ¬ (nothing ≡ just x)
+nothing≠just p = just≠nothing (sym p)
 
 just-inj : ∀ {x y : A} → just x ≡ just y → x ≡ y
 just-inj {x = x} = ap (from-just x)

--- a/src/Data/Nat/Solver.lagda.md
+++ b/src/Data/Nat/Solver.lagda.md
@@ -240,7 +240,8 @@ block x = x
 ⟦_⟧ₚ : Poly Nat n → Vec Nat n → Nat
 ⟦ const c ⟧ₚ env        = c
 ⟦ zerop ⟧ₚ   env        = 0
-⟦ p *X+ q ⟧ₚ (x₀ ∷ env) = ⟦ p ⟧ₚ (x₀ ∷ env) * x₀ + ⟦ q ⟧ₚ env
+⟦ p *X+ q ⟧ₚ v with vec-view v
+... | (x₀ ∷ env) = ⟦ p ⟧ₚ (x₀ ∷v env) * x₀ + ⟦ q ⟧ₚ env
 ```
 
 ### Soundness of the operations
@@ -252,16 +253,18 @@ zero polynomial really represents the function $f(x_0, \cdots, x_n) =
 
 ```agda
 sound-0ₚ : ∀ (env : Vec Nat n) → ⟦ 0ₚ ⟧ₚ env ≡ 0
-sound-0ₚ []        = refl
-sound-0ₚ (x ∷ env) = refl
+sound-0ₚ v with vec-view v
+... | []        = refl
+... | (x ∷ env) = refl
 ```
 
 We do the same for the constant polynomials:
 
 ```agda
 sound-constₚ : ∀ c → (env : Vec Nat n) → ⟦ constₚ c ⟧ₚ env ≡ c
-sound-constₚ c [] = refl
-sound-constₚ c (x ∷ env) = sound-constₚ c env
+sound-constₚ c v with vec-view v
+... | [] = refl
+... | (x ∷ env) = sound-constₚ c env
 ```
 
 At the risk of repeating ourselves, we also show the same for the
@@ -269,13 +272,13 @@ monomial $X_i$.
 
 ```agda
 sound-X[_] : ∀ i → (env : Vec Nat n) → ⟦ X[ i ] ⟧ₚ env ≡ lookup env i
-sound-X[ i ] _ with fin-view i
-sound-X[ .fzero ] (x₀ ∷ env) | zero =
+sound-X[ i ] v with vec-view v | fin-view i
+... | (x₀ ∷ env) | zero =
   ⟦ constₚ 1 ⟧ₚ env * x₀ + ⟦ 0ₚ ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-constₚ 1 env) (sound-0ₚ env) ⟩
   1 * x₀ + 0                           ≡⟨ +-zeror (1 * x₀) ⟩
   1 * x₀                               ≡⟨ *-onel x₀ ⟩
   x₀ ∎
-sound-X[ .(fsuc i) ] (_ ∷ env) | suc i = sound-X[ i ] env
+sound-X[ .(fsuc i) ] v | (_ ∷ env) | suc i = sound-X[ i ] env
 ```
 
 Now, for something more involved: let's show that addition of
@@ -290,17 +293,18 @@ sound-+ₚ (const c1) (const c2) env = refl
 sound-+ₚ zerop q env = refl
 sound-+ₚ (p *X+ r) zerop env =
   sym (+-zeror (⟦ (p *X+ r) +ₚ zerop ⟧ₚ env))
-sound-+ₚ (p *X+ r) (q *X+ s) (x₀ ∷ env) =
-  ⟦p+q⟧ * x₀ + ⟦r+s⟧                ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-+ₚ p q (x₀ ∷ env)) (sound-+ₚ r s env) ⟩
+sound-+ₚ (p *X+ r) (q *X+ s) v with vec-view v
+... | (x₀ ∷ env) =
+  ⟦p+q⟧ * x₀ + ⟦r+s⟧                ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-+ₚ p q (x₀ ∷v env)) (sound-+ₚ r s env) ⟩
   (⟦p⟧ + ⟦q⟧) * x₀ + (⟦r⟧ + ⟦s⟧)    ≡⟨ ap (λ ϕ → ϕ + (⟦r⟧ + ⟦s⟧)) (*-distrib-+r ⟦p⟧ ⟦q⟧ x₀) ⟩
   ⟦p⟧ * x₀ + ⟦q⟧ * x₀ + (⟦r⟧ + ⟦s⟧) ≡⟨ commute-inner (⟦p⟧ * x₀) (⟦q⟧ * x₀) ⟦r⟧ ⟦s⟧ ⟩
   ⟦p⟧ * x₀ + ⟦r⟧ + (⟦q⟧ * x₀ + ⟦s⟧) ∎
   where
-    ⟦p+q⟧ = ⟦ p +ₚ q ⟧ₚ (x₀ ∷ env)
+    ⟦p+q⟧ = ⟦ p +ₚ q ⟧ₚ (x₀ ∷v env)
     ⟦r+s⟧ = ⟦ r +ₚ s ⟧ₚ env
-    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷ env)
+    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷v env)
     ⟦r⟧ = ⟦ r ⟧ₚ env
-    ⟦q⟧ = ⟦ q ⟧ₚ (x₀ ∷ env)
+    ⟦q⟧ = ⟦ q ⟧ₚ (x₀ ∷v env)
     ⟦s⟧ = ⟦ s ⟧ₚ env
 ```
 
@@ -320,7 +324,7 @@ sound-*ₚ
   → ⟦ p *ₚ q ⟧ₚ env ≡ ⟦ p ⟧ₚ env * ⟦ q ⟧ₚ env
 sound-*ₚ'
   : ∀ p q → (x₀ : Nat) → (env : Vec Nat n)
-  → ⟦ p *ₚ' q ⟧ₚ (x₀ ∷ env) ≡ ⟦ p ⟧ₚ env * ⟦ q ⟧ₚ (x₀ ∷ env)
+  → ⟦ p *ₚ' q ⟧ₚ (x₀ ∷v env) ≡ ⟦ p ⟧ₚ env * ⟦ q ⟧ₚ (x₀ ∷v env)
 ```
 
 The first couple of cases of homogeneous multiplication don't look so
@@ -329,13 +333,14 @@ bad...
 ```agda
 sound-*ₚ (const c1) (const c2) env = refl
 sound-*ₚ zerop q env = refl
-sound-*ₚ (p *X+ r) zerop (x₀ ∷ env) =
-  ⟦ p *ₚ zerop ⟧ₚ (x₀ ∷ env) * x₀ + ⟦ 0ₚ ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-*ₚ p zerop (x₀ ∷ env)) (sound-0ₚ env) ⟩
+sound-*ₚ (p *X+ r) zerop v with vec-view v
+... | (x₀ ∷ env) =
+  ⟦ p *ₚ zerop ⟧ₚ (x₀ ∷v env) * x₀ + ⟦ 0ₚ ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-*ₚ p zerop (x₀ ∷v env)) (sound-0ₚ env) ⟩
   ⟦p⟧ * 0 * x₀ + 0                              ≡⟨ ap (λ ϕ → (ϕ * x₀) + 0) (*-zeror ⟦p⟧) ⟩
   0                                             ≡˘⟨ *-zeror (⟦p⟧ * x₀ + ⟦r⟧) ⟩
   (⟦p⟧ * x₀ + ⟦r⟧) * 0 ∎
   where
-    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷ env)
+    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷v env)
     ⟦r⟧ = ⟦ r ⟧ₚ env
 ```
 
@@ -346,11 +351,12 @@ There's not too much to be gained from dwelling on this, so let's move
 on.
 
 ```agda
-sound-*ₚ (p *X+ r) (q *X+ s) (x₀ ∷ env) =
+sound-*ₚ (p *X+ r) (q *X+ s) v with vec-view v
+... | (x₀ ∷ env) =
   ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + ⟦ 0ₚ +ₚ (r *ₚ s) ⟧ₚ env                ≡⟨ ap (λ ϕ → ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + ϕ) (sound-+ₚ 0ₚ (r *ₚ s) env) ⟩
   ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + (⟦ 0ₚ ⟧ₚ env + ⟦ r *ₚ s ⟧ₚ env)        ≡⟨ ap₂ (λ ϕ ψ → ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + (ϕ + ψ)) (sound-0ₚ env) (sound-*ₚ r s env) ⟩
-  ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + (⟦r⟧ * ⟦s⟧)                            ≡⟨ ap (λ ϕ → ϕ * x₀ + ⟦r⟧ * ⟦s⟧) (sound-+ₚ (p *ₚ (q *X+ s)) (r *ₚ' q) (x₀ ∷ env)) ⟩
-  (⟦p*⟨qx+s⟩⟧ + ⟦r*q⟧) * x₀ + ⟦r⟧ * ⟦s⟧                        ≡⟨ ap₂ (λ ϕ ψ → (ϕ + ψ) * x₀ + ⟦r⟧ * ⟦s⟧) (sound-*ₚ p (q *X+ s) (x₀ ∷ env)) (sound-*ₚ' r q x₀ env) ⟩
+  ⟦p*⟨qx+s⟩+r*q⟧ * x₀ + (⟦r⟧ * ⟦s⟧)                            ≡⟨ ap (λ ϕ → ϕ * x₀ + ⟦r⟧ * ⟦s⟧) (sound-+ₚ (p *ₚ (q *X+ s)) (r *ₚ' q) (x₀ ∷v env)) ⟩
+  (⟦p*⟨qx+s⟩⟧ + ⟦r*q⟧) * x₀ + ⟦r⟧ * ⟦s⟧                        ≡⟨ ap₂ (λ ϕ ψ → (ϕ + ψ) * x₀ + ⟦r⟧ * ⟦s⟧) (sound-*ₚ p (q *X+ s) (x₀ ∷v env)) (sound-*ₚ' r q x₀ env) ⟩
   (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) + ⟦r⟧ * ⟦q⟧) * x₀ + ⟦r⟧ * ⟦s⟧        ≡⟨ ap (λ ϕ → ϕ + ⟦r⟧ * ⟦s⟧) (*-distrib-+r (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧)) (⟦r⟧ * ⟦q⟧) x₀) ⟩
   ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + ⟦r⟧ * ⟦q⟧ * x₀ + ⟦r⟧ * ⟦s⟧     ≡˘⟨ +-associative (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀) (⟦r⟧ * ⟦q⟧ * x₀) (⟦r⟧ * ⟦s⟧) ⟩
   ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (⟦r⟧ * ⟦q⟧ * x₀ + ⟦r⟧ * ⟦s⟧)   ≡˘⟨ ap (λ ϕ →  ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (ϕ + ⟦r⟧ * ⟦s⟧)) (*-associative ⟦r⟧ ⟦q⟧ x₀) ⟩
@@ -359,12 +365,12 @@ sound-*ₚ (p *X+ r) (q *X+ s) (x₀ ∷ env) =
   ⟦p⟧ * x₀ * (⟦q⟧ * x₀ + ⟦s⟧) + ⟦r⟧ * (⟦q⟧ * x₀ + ⟦s⟧)         ≡˘⟨ *-distrib-+r (⟦p⟧ * x₀) ⟦r⟧ (⟦q⟧ * x₀ + ⟦s⟧) ⟩
   (⟦p⟧ * x₀ + ⟦r⟧) * (⟦q⟧ * x₀ + ⟦s⟧)                          ∎
   where
-    ⟦p*⟨qx+s⟩+r*q⟧ = ⟦ (p *ₚ (q *X+ s)) +ₚ (r *ₚ' q) ⟧ₚ (x₀ ∷ env)
-    ⟦p*⟨qx+s⟩⟧ = ⟦ p *ₚ (q *X+ s) ⟧ₚ (x₀ ∷ env)
-    ⟦r*q⟧ = ⟦ r *ₚ' q ⟧ₚ (x₀ ∷ env)
-    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷ env)
+    ⟦p*⟨qx+s⟩+r*q⟧ = ⟦ (p *ₚ (q *X+ s)) +ₚ (r *ₚ' q) ⟧ₚ (x₀ ∷v env)
+    ⟦p*⟨qx+s⟩⟧ = ⟦ p *ₚ (q *X+ s) ⟧ₚ (x₀ ∷v env)
+    ⟦r*q⟧ = ⟦ r *ₚ' q ⟧ₚ (x₀ ∷v env)
+    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷v env)
     ⟦r⟧ = ⟦ r ⟧ₚ env
-    ⟦q⟧ = ⟦ q ⟧ₚ (x₀ ∷ env)
+    ⟦q⟧ = ⟦ q ⟧ₚ (x₀ ∷v env)
     ⟦s⟧ = ⟦ s ⟧ₚ env
 ```
 
@@ -374,13 +380,13 @@ are nowhere near as bad.
 ```agda
 sound-*ₚ' p zerop x₀ env = sym (*-zeror (⟦ p ⟧ₚ env))
 sound-*ₚ' r (p *X+ q) x₀ env =
-  ⟦ r *ₚ' p ⟧ₚ (x₀ ∷ env) * x₀ + ⟦ r *ₚ q ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-*ₚ' r p x₀ env) (sound-*ₚ r q env) ⟩
+  ⟦ r *ₚ' p ⟧ₚ (x₀ ∷v env) * x₀ + ⟦ r *ₚ q ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-*ₚ' r p x₀ env) (sound-*ₚ r q env) ⟩
   ⟦r⟧ * ⟦p⟧ * x₀ + ⟦r⟧ * ⟦q⟧                     ≡˘⟨ ap (λ ϕ → ϕ + ⟦r⟧ * ⟦q⟧) (*-associative ⟦r⟧ ⟦p⟧ x₀) ⟩
   ⟦r⟧ * (⟦p⟧ * x₀) + ⟦r⟧ * ⟦q⟧                   ≡˘⟨ *-distrib-+l  (⟦p⟧ * x₀) ⟦q⟧ ⟦r⟧ ⟩
   ⟦r⟧ * (⟦p⟧ * x₀ + ⟦q⟧)                         ∎
   where
     ⟦r⟧ = ⟦ r ⟧ₚ env
-    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷ env)
+    ⟦p⟧ = ⟦ p ⟧ₚ (x₀ ∷v env)
     ⟦q⟧ = ⟦ q ⟧ₚ env
 ```
 

--- a/src/Data/Vec/Base.lagda.md
+++ b/src/Data/Vec/Base.lagda.md
@@ -4,42 +4,28 @@ open import 1Lab.Path
 open import 1Lab.Type
 
 open import Data.Product.NAry
+open import Data.Maybe.Base
+open import Data.List.Base as List using (List; []; _∷_; length)
+open import Data.Dec.Base
 open import Data.Fin.Base
-open import Data.Nat.Base
+open import Data.Nat.Base as Nat
+open import Data.Id.Base
+
+open import Meta.Idiom
+
+import Data.Irr
 ```
 -->
 
 ```agda
 module Data.Vec.Base where
 ```
-
-# Vectors
-
-The type `Vec`{.Agda} is a representation of n-ary tuples with
-coordinates drawn from A.
-
-```agda
-data Vec {ℓ} (A : Type ℓ) : Nat → Type ℓ where
-  []  : Vec A zero
-  _∷_ : ∀ {n} → A → Vec A n → Vec A (suc n)
-```
-
-We begin by establishing an elimination rule for `Vec`{.Agda}, along
-with the `head`{.Agda} and `tail`{.Agda} operations.
-
-```agda
-Vec-elim
-  : ∀ {ℓ ℓ'} {A : Type ℓ} (P : ∀ {n} → Vec A n → Type ℓ')
-  → P []
-  → (∀ {n} x (xs : Vec A n) → P xs → P (x ∷ xs))
-  → ∀ {n} (xs : Vec A n) → P xs
-Vec-elim P p[] p∷ [] = p[]
-Vec-elim P p[] p∷ (x ∷ xs) = p∷ x xs (Vec-elim P p[] p∷ xs)
-```
-
 <!--
 ```agda
-infixr 20 _∷_
+open import Data.List.Length public
+-- we need reexport make-irr for []v to work
+open Data.Irr using (make-irr) public
+open Data.Irr
 
 private variable
   ℓ : Level
@@ -48,80 +34,64 @@ private variable
 ```
 -->
 
+# Vectors
+
+The type `Vec`{.Agda} is a representation of n-ary tuples with
+coordinates drawn from A.
+
 ```agda
+record Vec {ℓ} (A : Type ℓ) (n : Nat) : Type ℓ where
+  constructor vec
+  field
+    lower   : List A
+    ⦃ len ⦄ : Irr (Length lower n)
+
+pattern []v = vec []
+
+infixr 20 _∷v_
+_∷v_ : ∀ {n} → A → Vec A n → Vec A (suc n)
+_∷v_ v (vec vs ⦃ p ⦄) = vec (v ∷ vs) ⦃ suc <$> p ⦄
+
+data Vec-view {ℓ} {A : Type ℓ} : {n : Nat} → Vec A n → Typeω where
+  []     : Vec-view []v
+  _∷_  : ∀ {n} a → (vs : Vec A n) → Vec-view {n = suc n} (a ∷v vs)
+
+vec-view : ∀ {n} (v : Vec A n) → Vec-view v
+vec-view {n = zero} []v = []
+vec-view {n = zero} (vec (x ∷ xs) ⦃ l ⦄) with () ← recover l
+vec-view {n = suc n} (vec (x ∷ xs)) = x ∷ vec xs
+  ⦃ len-uncons <$> auto ⦄
+vec-view {n = suc n} (vec [] ⦃ l ⦄) with () ← recover l
+
+list→vec : (xs : List A) → Vec A (length xs)
+list→vec xs = vec xs
+
 head : Vec A (suc n) → A
-head (x ∷ xs) = x
+head (vec (x ∷ xs)) = x
+head (vec [] ⦃ l ⦄) with () ← recover l
 
 tail : Vec A (suc n) → Vec A n
-tail (x ∷ xs) = xs
+tail v with (x ∷ xs) ← vec-view v = xs
 ```
 
-The type `Vec A n` [is equivalent to] the type $\rm{Fin}(n) \to A$, i.e., 
+The type `Vec A n` [is equivalent to] the type $\rm{Fin}(n) \to A$, i.e.,
 the functions from the [[standard finite set]] with $n$ elements to the
-type $A$. The halves of this equivalence are called `lookup`{.Agda} and 
+type $A$. The halves of this equivalence are called `lookup`{.Agda} and
 `tabulate`{.Agda}.
 
 [is equivalent to]: Data.Vec.Properties.html
 
 ```agda
 lookup : Vec A n → Fin n → A
-lookup xs n with fin-view n
-... | zero  = head xs
-... | suc i = lookup (tail xs) i
-```
-
-<!--
-```agda
-Vec-cast : {x y : Nat} → x ≡ y → Vec A x → Vec A y
-Vec-cast {A = A} {x = x} {y = y} p xs =
-  Vec-elim (λ {n} _ → (y : Nat) → n ≡ y → Vec A y)
-    (λ { zero _ → []
-       ; (suc x) p → absurd (zero≠suc p)
-       })
-    (λ { {n} head tail cast-tail zero 1+n=len → absurd (suc≠zero 1+n=len)
-       ; {n} head tail cast-tail (suc len) 1+n=len →
-          head ∷ cast-tail len (suc-inj 1+n=len)
-       })
-    xs y p
-```
--->
-
-```agda
-tabulate : (Fin n → A) → Vec A n
-tabulate {zero} f  = []
-tabulate {suc n} f = f fzero ∷ tabulate (λ x → f (fsuc x))
-```
-
-For a given length $n$, `Vec`{.Agda} is functorial. Here we show how the
-`map`{.Agda} action on morphisms, that this gives a functor is shown 
-[[elsewhere|functioriality of Vec]].
-
-```agda
-map : (A → B) → Vec A n → Vec B n
-map f [] = []
-map f (x ∷ xs) = f x ∷ map f xs
-```
-
-The following operations are also useful:
-
-```agda
-_++_ : ∀ {n k} → Vec A n → Vec A k → Vec A (n + k)
-[] ++ ys = ys
-(x ∷ xs) ++ ys = x ∷ (xs ++ ys)
-
-zip-with : (A → B → C) → Vec A n → Vec B n → Vec C n
-zip-with f [] [] = []
-zip-with f (x ∷ xs) (y ∷ ys) = f x y ∷ zip-with f xs ys
-
-replicate : (n : Nat) → A → Vec A n
-replicate zero a = []
-replicate (suc n) a = a ∷ replicate n a
+lookup (vec xs) (fin n) = from-just! _ $ List.!?-just xs n p where abstract
+  p : n Nat.< length xs
+  p = ≤-trans auto $ subst (Nat._≤ length xs) (has-length auto) auto
 ```
 
 ## List syntax {defines="list-syntax-for-vectors"}
 
 A similar type to `Vec`{.Agda} can be defined by _recursion_ as an
-iteraded `non-dependent product`{.Agda}. The resulting type `Vecₓ`{.Agda} 
+iteraded `non-dependent product`{.Agda}. The resulting type `Vecₓ`{.Agda}
 has the advantage of supporting usual tuple syntax, but is fiddlier to
 eliminate. This is solved by implementing the `From-product`{.Agda}
 typeclass for `Vec`{.Agda}, which enables list syntax for the latter.
@@ -131,10 +101,50 @@ instance
   From-prod-Vec : From-product A (Vec A)
   From-prod-Vec .From-product.from-prod = go where
     go : ∀ n → Vecₓ A n → Vec A n
-    go zero xs                = []
-    go (suc zero) xs          = xs ∷ []
-    go (suc (suc n)) (x , xs) = x ∷ go (suc n) xs
+    go zero xs                = []v
+    go (suc zero) xs          = xs ∷v []v
+    go (suc (suc n)) (x , xs) = x ∷v go (suc n) xs
 
-_ : Path (Vec Nat 3) [ 1 , 2 , 3 ] (1 ∷ 2 ∷ 3 ∷ [])
+_++_ : ∀ {n k} → Vec A n → Vec A k → Vec A (n + k)
+vec xs ++ vec ys = vec (xs List.++ ys) ⦃ liftA2 len-++ auto auto ⦄
+
+Vec-elim
+  : ∀ {ℓ ℓ'} {A : Type ℓ} (P : ∀ {n} → Vec A n → Type ℓ')
+  → P []v
+  → (∀ {n} x (xs : Vec A n) → P xs → P (x ∷v xs))
+  → ∀ {n} (xs : Vec A n) → P xs
+Vec-elim P p[] p∷ v with vec-view v
+... | [] = p[]
+... | (x ∷ xs) = p∷ x xs $ Vec-elim P p[] p∷ xs
+```
+
+<!--
+```agda
+Vec-cast : {x y : Nat} → x ≡ y → Vec A x → Vec A y
+Vec-cast {A = A} {x = x} {y = y} p (vec l ⦃ len ⦄) =
+  vec l ⦃ subst (λ n → Length l n) p <$> len ⦄
+```
+-->
+
+```agda
+tabulate : (Fin n → A) → Vec A n
+tabulate v  = vec (List.tabulate v) ⦃ forget (len-tabulate v) ⦄
+
+instance
+  Map-Vec : ∀ {n} → Map (eff (λ A → Vec A n ) )
+  Map-Vec .Map.map f (vec l) = vec (f <$> l) ⦃ len-map <$> auto ⦄
+
+zip :  Vec A n → Vec B n → Vec (A × B) n
+zip (vec u) (vec v) = vec (List.zip u v) ⦃ liftA2 len-zip auto auto ⦄
+
+zip-with : (A → B → C) → Vec A n → Vec B n → Vec C n
+zip-with f (vec u) (vec v) = vec (List.zip-with f u v)
+  ⦃ liftA2 len-zip-with auto auto ⦄
+
+replicate : (n : Nat) → A → Vec A n
+replicate zero a = []v
+replicate (suc n) a = a ∷v replicate n a
+
+_ : Path (Vec Nat 3) [ 1 , 2 , 3 ] (1 ∷v 2 ∷v 3 ∷v []v)
 _ = refl
 ```

--- a/src/Data/Vec/Properties.lagda.md
+++ b/src/Data/Vec/Properties.lagda.md
@@ -2,7 +2,9 @@
 ```agda
 open import 1Lab.Prelude
 
+open import Data.List.Base hiding (head ; tail ; lookup ; tabulate ; _++_)
 open import Data.Fin.Base
+open import Data.Irr
 
 import Data.Vec.Base as Vec
 
@@ -26,14 +28,15 @@ private variable
 
 # Properties of vectors
 
-In this module we show properties of vectors, including 
+In this module we show properties of vectors, including
 `the equivalence`{.Agda ident="Vec≃Fun"} between vectors of length $n$
 and functions from `Fin n`{.Agda ident="Fin"}.
 
 ```agda
 tabulate-lookup : (xs : Vec A n) → tabulate (lookup xs) ≡ xs
-tabulate-lookup []       = refl
-tabulate-lookup (x ∷ xs) = ap (x ∷_) (tabulate-lookup xs)
+tabulate-lookup v with vec-view v
+... | []       = refl
+... | (x ∷ xs) = ap (x ∷v_) (tabulate-lookup xs)
 
 lookup-tabulate : (xs : Fin n → A) (i : Fin n) → lookup (tabulate xs) i ≡ xs i
 lookup-tabulate xs i with fin-view i
@@ -63,10 +66,12 @@ Vec-is-hlevel m Ahl = Equiv→is-hlevel m Vec≃Fun (fun-is-hlevel m Ahl)
 <!--
 ```agda
 instance
-  H-Level-Vec : 
+  H-Level-Vec :
     ∀ {m} {A : Type ℓ} {n} → ⦃ H-Level A n ⦄
     → H-Level (Vec A m) n
   H-Level-Vec {n = n} .H-Level.has-hlevel = Vec-is-hlevel n (hlevel n)
+
+unquoteDecl ap-vec = declare-record-path ap-vec (quote Vec)
 ```
 -->
 
@@ -77,11 +82,14 @@ Vec-path
   : ∀ {A : Type ℓ} {n} {v w : Vec A (suc n)}
   → (head v ≡ head w) → (tail v ≡ tail w)
   → v ≡ w
-
-Vec-path {v = _ ∷ _} {w = _ ∷ _} p q i = p i ∷ q i
+Vec-path {v = vec (x ∷ xs)} {w = vec (y ∷ ys)} p q = ap-vec $ ap₂ _∷_ p (ap Vec.lower q)
+Vec-path {v = vec [] ⦃ l ⦄} with () ← recover l
+Vec-path {w = vec [] ⦃ l ⦄} with () ← recover l
 
 []-unique : ∀ {A : Type ℓ} → is-contr (Vec A 0)
-[]-unique {A = A} = contr [] λ where [] → refl
+[]-unique {A = A} .centre = []v
+[]-unique {A = A} .paths v with vec-view v
+... | [] = refl
 ```
 
 ## Functoriality {defines="functioriality-of-Vec"}
@@ -89,20 +97,20 @@ Vec-path {v = _ ∷ _} {w = _ ∷ _} p q i = p i ∷ q i
 Here we show the functoriality of `Vec.map`{.Agda}.
 
 ```agda
-map-lookup : ∀ (f : A → B) (xs : Vec A n) i → lookup (Vec.map f xs) i ≡ f (lookup xs i)
-map-lookup _ _ i with fin-view i
-map-lookup f (x ∷ xs) _ | zero  = refl
-map-lookup f (x ∷ xs) _ | suc i = map-lookup f xs i
+map-lookup : (f : A → B) (xs : Vec A n) → ∀ i → lookup (map f xs) i ≡ f (lookup xs i)
+map-lookup f v i with vec-view v | fin-view i
+... | (x ∷ xs) | zero  = refl
+... | (x ∷ xs) | suc i = map-lookup f xs i
 
-map-id : (xs : Vec A n) → Vec.map (λ x → x) xs ≡ xs
+map-id : {A : Type ℓ} (xs : Vec A n) → map (λ x → x) xs ≡ xs
 map-id xs = Lookup.injective₂ (funext λ i → map-lookup _ xs i) refl
 
 map-comp
   : (xs : Vec A n) (f : A → B) (g : B → C)
-  → Vec.map (λ x → g (f x)) xs ≡ Vec.map g (Vec.map f xs)
+  → map (λ x → g (f x)) xs ≡ map g (map f xs)
 map-comp xs f g = Lookup.injective $ funext λ i →
-  lookup (Vec.map (λ x → g (f x)) xs) i ≡⟨ map-lookup (λ x → g (f x)) xs i ⟩
-  g (f (lookup xs i))                   ≡˘⟨ ap g (map-lookup f xs i) ⟩
-  g (lookup (Vec.map f xs) i)           ≡˘⟨ map-lookup g (Vec.map f xs) i ⟩
-  lookup (Vec.map g (Vec.map f xs)) i   ∎
+  lookup (map (λ x → g (f x)) xs) i ≡⟨ map-lookup (λ x → g (f x)) xs i ⟩
+  g (f (lookup xs i))               ≡˘⟨ ap g (map-lookup f xs i) ⟩
+  g (lookup (map f xs) i)           ≡˘⟨ map-lookup g (map f xs) i ⟩
+  lookup (map g (map f xs)) i       ∎
 ```

--- a/src/Meta/Idiom.lagda.md
+++ b/src/Meta/Idiom.lagda.md
@@ -8,6 +8,14 @@ open import 1Lab.Type
 module Meta.Idiom where
 ```
 
+<!--
+```agda
+private variable
+  ℓ ℓ' : Level
+  A B C : Type ℓ
+```
+-->
+
 # Meta: Idiom
 
 The `Idiom`{.Agda} class, probably better known as `Applicative` (from
@@ -33,14 +41,14 @@ argument to the `eff`{.Agda} constructor.
 record Map (M : Effect) : Typeω where
   private module M = Effect M
   field
-    map : ∀ {ℓ} {ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → M.₀ A → M.₀ B
+    map : (A → B) → M.₀ A → M.₀ B
 
 record Idiom (M : Effect) : Typeω where
   private module M = Effect M
   field
     ⦃ Map-idiom ⦄ : Map M
-    pure  : ∀ {ℓ} {A : Type ℓ} → A → M.₀ A
-    _<*>_ : ∀ {ℓ} {ℓ'} {A : Type ℓ} {B : Type ℓ'} → M.₀ (A → B) → M.₀ A → M.₀ B
+    pure  : A → M.₀ A
+    _<*>_ : M.₀ (A → B) → M.₀ A → M.₀ B
 
   infixl 4 _<*>_
 
@@ -49,21 +57,20 @@ open Map   ⦃ ... ⦄ public
 
 infixl 4 _<$>_ _<&>_
 
-_<$>_ : ∀ {ℓ ℓ'} {M : Effect} ⦃ _ : Map M ⦄ {A : Type ℓ} {B : Type ℓ'}
-      → (A → B) → M .Effect.₀ A → M .Effect.₀ B
+private variable
+  M N : Effect
+
+_<$>_ : ⦃ _ : Map M ⦄ → (A → B) → M .Effect.₀ A → M .Effect.₀ B
 f <$> x = map f x
 
-_<$_ : ∀ {ℓ ℓ'} {M : Effect} ⦃ _ : Map M ⦄ {A : Type ℓ} {B : Type ℓ'}
-      → B → M .Effect.₀ A → M .Effect.₀ B
+_<$_ : ⦃ _ : Map M ⦄ → B → M .Effect.₀ A → M .Effect.₀ B
 c <$ x = map (λ _ → c) x
 
-_<&>_ : ∀ {ℓ ℓ'} {M : Effect} ⦃ _ : Map M ⦄ {A : Type ℓ} {B : Type ℓ'}
-      → M .Effect.₀ A → (A → B) → M .Effect.₀ B
+_<&>_ : ⦃ _ : Map M ⦄ → M .Effect.₀ A → (A → B) → M .Effect.₀ B
 x <&> f = map f x
 
 module _
   {M N : Effect} (let module M = Effect M; module N = Effect N) ⦃ _ : Map M ⦄ ⦃ _ : Map N ⦄
-  {ℓ} {ℓ'} {A : Type ℓ} {B : Type ℓ'}
   where
 
   _<<$>>_ : (A → B) → M.₀ (N.₀ A) → M.₀ (N.₀ B)
@@ -72,13 +79,16 @@ module _
   _<<&>>_ : M.₀ (N.₀ A) → (A → B) → M.₀ (N.₀ B)
   x <<&>> f = f <<$>> x
 
-when : ∀ {M : Effect} (let module M = Effect M) ⦃ app : Idiom M ⦄
-     → Bool → M.₀ ⊤ → M.₀ ⊤
+when : (let module M = Effect M) ⦃ app : Idiom M ⦄ → Bool → M.₀ ⊤ → M.₀ ⊤
 when true  t = t
 when false _ = pure tt
 
-unless : ∀ {M : Effect} (let module M = Effect M) ⦃ app : Idiom M ⦄
-       → Bool → M.₀ ⊤ → M.₀ ⊤
+unless : (let module M = Effect M) ⦃ app : Idiom M ⦄ → Bool → M.₀ ⊤ → M.₀ ⊤
 unless false t = t
 unless true  _ = pure tt
+
+liftA2 : (let module M = Effect M) ⦃ app : Idiom M ⦄
+       → (A → B → C) →  M.₀ A → M.₀ B → M.₀ C
+liftA2 f x = (_<*>_) (map f x)
+
 ```

--- a/src/Realisability/Base.lagda.md
+++ b/src/Realisability/Base.lagda.md
@@ -102,14 +102,14 @@ id⊢ : [ id ] P ⊢ P
 id⊢ {P = P} = record where
   realiser = val ⟨ x ⟩ x
 
-  tracks ha = subst-∈ (P _) ha (abs-β _ [] (_ , P _ .def ha))
+  tracks ha = subst-∈ (P _) ha (abs-β _ []v (_ , P _ .def ha))
 
 _∘⊢_ : ∀ {f g} → [ g ] Q ⊢ R → [ f ] P ⊢ Q → [ g ∘ f ] P ⊢ R
 _∘⊢_ {R = R} {P = P} α β = record where
   realiser = val ⟨ x ⟩ α `· (β `· x)
 
   tracks {a = a} ha = subst-∈ (R _) (α .tracks (β .tracks ha)) $
-    (val ⟨ x ⟩ α `· (β `· x)) ⋆ a ≡⟨ abs-β _ [] (a , P _ .def ha) ⟩
+    (val ⟨ x ⟩ α `· (β `· x)) ⋆ a ≡⟨ abs-β _ []v (a , P _ .def ha) ⟩
     α ⋆ (β ⋆ a)                   ∎
 ```
 

--- a/src/Realisability/Data/Bool.lagda.md
+++ b/src/Realisability/Data/Bool.lagda.md
@@ -62,16 +62,16 @@ selects its second argument.
 ```agda
 abstract
   `true↓₁ : ⌞ a ⌟ → ⌞ `true ⋆ a ⌟
-  `true↓₁ x = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , x) ∷ []))) (abs↓ _ _)
+  `true↓₁ x = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , x) ∷v []v))) (abs↓ _ _)
 
   `false↓₁ : ⌞ a ⌟ → ⌞ `false ⋆ a ⌟
-  `false↓₁ ah = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , ah) ∷ []))) (abs↓ _ _)
+  `false↓₁ ah = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , ah) ∷v []v))) (abs↓ _ _)
 
   `true-β : ⌞ a ⌟ → ⌞ b ⌟ → `true ⋆ a ⋆ b ≡ a
-  `true-β {a} {b} ah bh = abs-βₙ [] ((b , bh) ∷ (a , ah) ∷ [])
+  `true-β {a} {b} ah bh = abs-βₙ []v ((b , bh) ∷v (a , ah) ∷v []v)
 
   `false-β : ⌞ a ⌟ → ⌞ b ⌟ → `false ⋆ a ⋆ b ≡ b
-  `false-β {a} {b} ah bh = abs-βₙ [] ((b , bh) ∷ (a , ah) ∷ [])
+  `false-β {a} {b} ah bh = abs-βₙ []v ((b , bh) ∷v (a , ah) ∷v []v)
 ```
 
 We can define negation using `` `if_then_else_ ``{.Agda}, and show that
@@ -83,8 +83,8 @@ it computes as expected.
 
 abstract
   `not-βt : `not ⋆ `true ≡ `false .fst
-  `not-βt = abs-β _ [] `true ∙ abs-βₙ [] (`true ∷ `false ∷ [])
+  `not-βt = abs-β _ []v `true ∙ abs-βₙ []v (`true ∷v `false ∷v []v)
 
   `not-βf : `not ⋆ `false ≡ `true .fst
-  `not-βf = abs-β _ [] `false ∙ abs-βₙ [] (`true ∷ `false ∷ [])
+  `not-βf = abs-β _ []v `false ∙ abs-βₙ []v (`true ∷v `false ∷v []v)
 ```

--- a/src/Realisability/Data/Nat.lagda.md
+++ b/src/Realisability/Data/Nat.lagda.md
@@ -86,7 +86,7 @@ abstract
   `num-suc x = sym (abs-β _ _ (`num x))
 
   `suc↓₁ : ⌞ x ⌟ → ⌞ `suc ⋆ x ⌟
-  `suc↓₁ ah = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , ah) ∷ []))) (`pair↓₂ (`false .snd) ah)
+  `suc↓₁ ah = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , ah) ∷v []v))) (`pair↓₂ (`false .snd) ah)
 
   `iszero-zero : `iszero ⋆ `zero ≡ `true .fst
   `iszero-zero = abs-β _ _ `zero ∙ abs-β _ _ (_ , abs↓ _ _)
@@ -101,7 +101,7 @@ abstract
   `pred-zero =
     `pred ⋆ `zero                             ≡⟨ abs-β _ _ `zero ⟩
     ⌜ `fst ⋆ `zero ⌝ ⋆ `zero ⋆ (`snd ⋆ `zero) ≡⟨ ap (λ e → e ⋆ `zero ⋆ (`snd ⋆ `zero)) (`iszero-zero) ⟩
-    `true ⋆ `zero ⋆ (`snd ⋆ `zero)            ≡⟨ abs-βₙ [] ((_ , subst ⌞_⌟ (sym rem₁) (abs↓ _ _)) ∷ `zero ∷ []) ⟩
+    `true ⋆ `zero ⋆ (`snd ⋆ `zero)            ≡⟨ abs-βₙ []v ((_ , subst ⌞_⌟ (sym rem₁) (abs↓ _ _)) ∷v `zero ∷v []v) ⟩
     `zero .fst                                ∎
     where
       rem₁ : `snd ⋆ `zero ≡ `false .fst
@@ -112,7 +112,7 @@ abstract
     `pred ⋆ (`suc ⋆ x)                                   ≡⟨ abs-β _ _ (_ , `suc↓₁ xh) ⟩
     ⌜ `fst ⋆ (`suc ⋆ x) ⌝ ⋆ `zero ⋆ (`snd ⋆ (`suc ⋆ x))  ≡⟨ ap (λ e → e ⋆ `zero ⋆ (`snd ⋆ (`suc ⋆ x))) (ap (`fst ⋆_) (abs-β _ _ (_ , xh)) ∙ `fst-β (`false .snd) xh) ⟩
     `false ⋆ `zero ⋆ ⌜ `snd ⋆ (`suc ⋆ x) ⌝               ≡⟨ ap (λ e → (`false ⋆ `zero) ⋆ e) (ap (`snd ⋆_) (abs-β _ _ (_ , xh)) ∙ `snd-β (`false .snd) xh) ⟩
-    `false ⋆ `zero ⋆ x                                   ≡⟨ abs-βₙ [] ((_ , xh) ∷ `zero ∷ []) ⟩
+    `false ⋆ `zero ⋆ x                                   ≡⟨ abs-βₙ []v ((_ , xh) ∷v `zero ∷v []v) ⟩
     x                                                    ∎
 
 ```
@@ -163,28 +163,28 @@ that it computes as stated.
 ```agda
 abstract
   `primrec↓₁ : ⌞ z ⌟ → ⌞ `primrec ⋆ z ⌟
-  `primrec↓₁ zh = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , zh) ∷ []))) (abs↓ _ _)
+  `primrec↓₁ zh = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , zh) ∷v []v))) (abs↓ _ _)
 
   `primrec↓₂ : ⌞ z ⌟ → ⌞ f ⌟ → ⌞ `primrec ⋆ z ⋆ f ⌟
-  `primrec↓₂ zh fh = subst ⌞_⌟ (sym (abs-βₙ [] ((_ , fh) ∷ (_ , zh) ∷ []))) (abs↓ _ _)
+  `primrec↓₂ zh fh = subst ⌞_⌟ (sym (abs-βₙ []v ((_ , fh) ∷v (_ , zh) ∷v []v))) (abs↓ _ _)
 
   `primrec-zero : ⌞ z ⌟ → ⌞ f ⌟ → `primrec ⋆ z ⋆ f ⋆ `zero ≡ z
   `primrec-zero {z} {f} zh fh =
-    `primrec ⋆ z ⋆ f ⋆ `zero                                     ≡⟨ abs-βₙ [] (`zero ∷ (_ , fh) ∷ (_ , zh) ∷ []) ⟩
+    `primrec ⋆ z ⋆ f ⋆ `zero                                     ≡⟨ abs-βₙ []v (`zero ∷v (_ , fh) ∷v (_ , zh) ∷v []v) ⟩
     ⌜ `Z ⋆ `worker ⋆ z ⌝ ⋆ f ⋆ `zero ⋆ `zero                     ≡⟨ ap (λ e → e ⋆ f ⋆ `zero ⋆ `zero) (`Z-β (`worker .snd) zh) ⟩
-    ⌜ `worker ⋆ (`Z ⋆ `worker) ⋆ z ⋆ f ⋆ `zero ⌝ ⋆ `zero         ≡⟨ ap (λ e → e ⋆ `zero) (abs-βₙ [] (`zero ∷ (_ , fh) ∷ (_ , zh) ∷ (_ , `Z↓₁ (`worker .snd)) ∷ [])) ⟩
+    ⌜ `worker ⋆ (`Z ⋆ `worker) ⋆ z ⋆ f ⋆ `zero ⌝ ⋆ `zero         ≡⟨ ap (λ e → e ⋆ `zero) (abs-βₙ []v (`zero ∷v (_ , fh) ∷v (_ , zh) ∷v (_ , `Z↓₁ (`worker .snd)) ∷v []v)) ⟩
     ⌜ `iszero ⋆ `zero ⋆ (`true ⋆ z) ⌝ % _ % `zero .fst           ≡⟨ ap₂ _%_ (ap₂ _%_ (ap₂ _%_ `iszero-zero refl) refl ∙ `true-β (`true↓₁ zh) (abs↓ _ _)) refl ⟩
     `true ⋆ z ⋆ `zero .fst                                       ≡⟨ `true-β zh (`zero .snd) ⟩
     z                                                            ∎
 
   `primrec-suc : ⌞ z ⌟ → ⌞ f ⌟ → ⌞ x ⌟ → `primrec ⋆ z ⋆ f ⋆ (`suc ⋆ x) ≡ f ⋆ x ⋆ (`primrec ⋆ z ⋆ f ⋆ x)
   `primrec-suc {z} {f} {x} zh fh xh =
-    `primrec ⋆ z ⋆ f ⋆ (`suc ⋆ x)                                                 ≡⟨ abs-βₙ [] ((_ , `suc↓₁ xh) ∷ (_ , fh) ∷ (_ , zh) ∷ []) ⟩
+    `primrec ⋆ z ⋆ f ⋆ (`suc ⋆ x)                                                 ≡⟨ abs-βₙ []v ((_ , `suc↓₁ xh) ∷v (_ , fh) ∷v (_ , zh) ∷v []v) ⟩
     ⌜ `Z ⋆ `worker ⋆ z ⌝ ⋆ f ⋆ (`suc ⋆ x) ⋆ `zero                                 ≡⟨ ap (λ e → e ⋆ f ⋆ (`suc ⋆ x) ⋆ `zero) (`Z-β (`worker .snd) zh) ⟩
-    `worker ⋆ (`Z ⋆ `worker) ⋆ z ⋆ f ⋆ (`suc ⋆ x) ⋆ `zero                         ≡⟨ ap (λ e → e % `zero .fst) (abs-βₙ [] ((_ , `suc↓₁ xh) ∷ (_ , fh) ∷ (_ , zh) ∷ (_ , `Z↓₁ (`worker .snd)) ∷ [])) ⟩
-    `iszero ⋆ (`suc ⋆ x) ⋆ (`true ⋆ z) % _ % `zero .fst                           ≡⟨ ap₂ _%_ (ap₂ _%_ (ap₂ _%_ (`iszero-suc xh) refl) refl ∙ `false-β (`true↓₁ zh) (abs↓ _ _)) refl ∙ abs-βₙ ((`suc ⋆ x , `suc↓₁ xh) ∷ (f , fh) ∷ (z , zh) ∷ (`Z ⋆ `worker , `Z↓₁ (`worker .snd)) ∷ []) (`zero ∷ []) ⟩
+    `worker ⋆ (`Z ⋆ `worker) ⋆ z ⋆ f ⋆ (`suc ⋆ x) ⋆ `zero                         ≡⟨ ap (λ e → e % `zero .fst) (abs-βₙ []v ((_ , `suc↓₁ xh) ∷v (_ , fh) ∷v (_ , zh) ∷v (_ , `Z↓₁ (`worker .snd)) ∷v []v)) ⟩
+    `iszero ⋆ (`suc ⋆ x) ⋆ (`true ⋆ z) % _ % `zero .fst                           ≡⟨ ap₂ _%_ (ap₂ _%_ (ap₂ _%_ (`iszero-suc xh) refl) refl ∙ `false-β (`true↓₁ zh) (abs↓ _ _)) refl ∙ abs-βₙ ((`suc ⋆ x , `suc↓₁ xh) ∷v (f , fh) ∷v (z , zh) ∷v (`Z ⋆ `worker , `Z↓₁ (`worker .snd)) ∷v []v) (`zero ∷v []v) ⟩
     f % `pred ⋆ (`suc ⋆ x) % `Z ⋆ `worker ⋆ z ⋆ f ⋆ (`pred ⋆ (`suc ⋆ x)) ⋆ `zero  ≡⟨ ap (λ e → f % e % `Z ⋆ `worker ⋆ z ⋆ f ⋆ e ⋆ `zero) (`pred-suc xh) ⟩
-    f ⋆ x ⋆ (`Z ⋆ `worker ⋆ z ⋆ f ⋆ x ⋆ `zero)                                    ≡⟨ ap₂ _%_ refl (sym (abs-βₙ [] ((_ , xh) ∷ (_ , fh) ∷ (_ , zh) ∷ []))) ⟩
+    f ⋆ x ⋆ (`Z ⋆ `worker ⋆ z ⋆ f ⋆ x ⋆ `zero)                                    ≡⟨ ap₂ _%_ refl (sym (abs-βₙ []v ((_ , xh) ∷v (_ , fh) ∷v (_ , zh) ∷v []v))) ⟩
     f ⋆ x ⋆ (`primrec ⋆ z ⋆ f ⋆ x)                                                ∎
 ```
 

--- a/src/Realisability/Data/Pair.lagda.md
+++ b/src/Realisability/Data/Pair.lagda.md
@@ -72,19 +72,19 @@ compute as expected.
 ```agda
 abstract
   `pair↓₂ : ⌞ a ⌟ → ⌞ b ⌟ → ⌞ `pair ⋆ a ⋆ b ⌟
-  `pair↓₂ {a} {b} ah bh = subst ⌞_⌟ (sym (abs-βₙ [] ((b , bh) ∷ (a , ah) ∷ []))) (abs↓ _ _)
+  `pair↓₂ {a} {b} ah bh = subst ⌞_⌟ (sym $ abs-βₙ []v ((b , bh) ∷v (a , ah) ∷v []v)) (abs↓ _ _)
 
   `fst-β : ⌞ a ⌟ → ⌞ b ⌟ → `fst ⋆ (`pair ⋆ a ⋆ b) ≡ a
   `fst-β {a} {b} ah bh =
-    `fst ⋆ (`pair ⋆ a ⋆ b)  ≡⟨ abs-β _ [] (_ , `pair↓₂ ah bh) ⟩
-    `pair ⋆ a ⋆ b ⋆ `true   ≡⟨ abs-βₙ [] (`true ∷ (b , bh) ∷ (a , ah) ∷ []) ⟩
+    `fst ⋆ (`pair ⋆ a ⋆ b)  ≡⟨ abs-β _ []v (_ , `pair↓₂ ah bh) ⟩
+    `pair ⋆ a ⋆ b ⋆ `true   ≡⟨ abs-βₙ []v (`true ∷v (b , bh) ∷v (a , ah) ∷v []v) ⟩
     `true ⋆ a ⋆ b           ≡⟨ `true-β ah bh ⟩
     a                       ∎
 
   `snd-β : ⌞ a ⌟ → ⌞ b ⌟ → `snd ⋆ (`pair ⋆ a ⋆ b) ≡ b
   `snd-β {a} {b} ah bh =
-    `snd ⋆ (`pair ⋆ a ⋆ b)  ≡⟨ abs-β _ [] (_ , `pair↓₂ ah bh) ⟩
-    `pair ⋆ a ⋆ b ⋆ `false  ≡⟨ abs-βₙ [] (`false ∷ (b , bh) ∷ (a , ah) ∷ []) ⟩
+    `snd ⋆ (`pair ⋆ a ⋆ b)  ≡⟨ abs-β _ []v (_ , `pair↓₂ ah bh) ⟩
+    `pair ⋆ a ⋆ b ⋆ `false  ≡⟨ abs-βₙ []v (`false ∷v (b , bh) ∷v (a , ah) ∷v []v) ⟩
     `false ⋆ a ⋆ b          ≡⟨ `false-β ah bh ⟩
     b                       ∎
 ```

--- a/src/Realisability/Data/Sum.lagda.md
+++ b/src/Realisability/Data/Sum.lagda.md
@@ -62,20 +62,20 @@ pattern matching computes as expected.
 ```agda
 abstract
   `inl↓₁ : ⌞ x ⌟ → ⌞ `inl ⋆ x ⌟
-  `inl↓₁ {x} hx = subst ⌞_⌟ (sym (abs-β _ [] (x , hx))) (`pair↓₂ (`true .snd) hx)
+  `inl↓₁ {x} hx = subst ⌞_⌟ (sym (abs-β _ []v (x , hx))) (`pair↓₂ (`true .snd) hx)
 
   `inr↓₁ : ⌞ x ⌟ → ⌞ `inr ⋆ x ⌟
-  `inr↓₁ {x} hx = subst ⌞_⌟ (sym (abs-β _ [] (x , hx))) (`pair↓₂ (`false .snd) hx)
+  `inr↓₁ {x} hx = subst ⌞_⌟ (sym (abs-β _ []v (x , hx))) (`pair↓₂ (`false .snd) hx)
 
   `match↓₂ : ⌞ f ⌟ → ⌞ g ⌟ → ⌞ `match ⋆ f ⋆ g ⌟
-  `match↓₂ {f = f} {g} hf hg = subst ⌞_⌟ (sym (abs-βₙ [] ((g , hg) ∷ (f , hf) ∷ []))) (abs↓ _ _)
+  `match↓₂ {f = f} {g} hf hg = subst ⌞_⌟ (sym (abs-βₙ []v ((g , hg) ∷v (f , hf) ∷v []v))) (abs↓ _ _)
 
   `match-βl
     : ⌞ x ⌟ → ⌞ f ⌟ → ⌞ g ⌟
     → `match ⋆ f ⋆ g ⋆ (`inl ⋆ x) ≡ f ⋆ x
   `match-βl {x = x} {f} {g} hx hf hg =
-    `match ⋆ f ⋆ g ⋆ (`inl ⋆ x)                                        ≡⟨ abs-βₙ [] ((`inl ⋆ x , `inl↓₁ hx) ∷ (g , hg) ∷ (f , hf) ∷ []) ⟩
-    `fst ⋆ ⌜ `inl ⋆ x ⌝ ⋆ f ⋆ g ⋆ (`snd ⋆ ⌜ `inl ⋆ x ⌝)                ≡⟨ ap! (abs-β _ [] (x , hx)) ⟩
+    `match ⋆ f ⋆ g ⋆ (`inl ⋆ x)                                        ≡⟨ abs-βₙ []v ((`inl ⋆ x , `inl↓₁ hx) ∷v (g , hg) ∷v (f , hf) ∷v []v) ⟩
+    `fst ⋆ ⌜ `inl ⋆ x ⌝ ⋆ f ⋆ g ⋆ (`snd ⋆ ⌜ `inl ⋆ x ⌝)                ≡⟨ ap! (abs-β _ []v (x , hx)) ⟩
     `fst ⋆ (`pair ⋆ `true ⋆ x) ⋆ f ⋆ g ⋆ (`snd ⋆ (`pair ⋆ `true ⋆ x))  ≡⟨ ap₂ (λ e p → e % f % g % p) (`fst-β (`true .snd) hx) (`snd-β (`true .snd) hx) ⟩
     `true ⋆ f ⋆ g ⋆ x                                                  ≡⟨ ap (λ e → e ⋆ x) (`true-β hf hg) ⟩
     f ⋆ x                                                              ∎
@@ -84,8 +84,8 @@ abstract
     : ⌞ x ⌟ → ⌞ f ⌟ → ⌞ g ⌟
     → `match ⋆ f ⋆ g ⋆ (`inr ⋆ x) ≡ g ⋆ x
   `match-βr {x = x} {f} {g} hx hf hg =
-    `match ⋆ f ⋆ g ⋆ (`inr ⋆ x)                                          ≡⟨ abs-βₙ [] ((`inr ⋆ x , `inr↓₁ hx) ∷ (g , hg) ∷ (f , hf) ∷ []) ⟩
-    `fst ⋆ ⌜ `inr ⋆ x ⌝ ⋆ f ⋆ g ⋆ (`snd ⋆ ⌜ `inr ⋆ x ⌝)                  ≡⟨ ap! (abs-β _ [] (x , hx)) ⟩
+    `match ⋆ f ⋆ g ⋆ (`inr ⋆ x)                                          ≡⟨ abs-βₙ []v ((`inr ⋆ x , `inr↓₁ hx) ∷v (g , hg) ∷v (f , hf) ∷v []v) ⟩
+    `fst ⋆ ⌜ `inr ⋆ x ⌝ ⋆ f ⋆ g ⋆ (`snd ⋆ ⌜ `inr ⋆ x ⌝)                  ≡⟨ ap! (abs-β _ []v (x , hx)) ⟩
     `fst ⋆ (`pair ⋆ `false ⋆ x) ⋆ f ⋆ g ⋆ (`snd ⋆ (`pair ⋆ `false ⋆ x))  ≡⟨ ap₂ (λ e p → e % f % g % p) (`fst-β (`false .snd) hx) (`snd-β (`false .snd) hx) ⟩
     `false ⋆ f ⋆ g ⋆ x                                                   ≡⟨ ap (λ e → e ⋆ x) (`false-β hf hg) ⟩
     g ⋆ x                                                                ∎

--- a/src/Realisability/PCA.lagda.md
+++ b/src/Realisability/PCA.lagda.md
@@ -142,7 +142,7 @@ term in an extended environment.
   abstract
     eval-inst
       : (t : Term A (suc n)) (x : ↯⁺ A) (ρ : Vec (↯⁺ A) n)
-      → eval (inst t (const x)) ρ ≡ eval t (x ∷ ρ)
+      → eval (inst t (const x)) ρ ≡ eval t (x ∷v ρ)
     eval-inst (var i) y ρ with fin-view i
     ... | zero  = refl
     ... | suc j = refl
@@ -194,16 +194,20 @@ combinator and of the $\beta$ law.</summary>
   absₙ (suc k) e = absₙ k (abs e)
 
   _%ₙ_ : ∀ {n} → ↯ A → Vec (↯⁺ A) n → ↯ A
-  a %ₙ []       = a
-  a %ₙ (b ∷ bs) = (a %ₙ bs) % b .fst
+  a %ₙ v with vec-view v
+  ... | []       = a
+  ... | (b ∷ bs) = (a %ₙ bs) % b .fst
 
   abstract
     abs-βₙ
       : {k n : Nat} {e : Term A (k + n)}
       → (ρ : Vec (↯⁺ A) n) (as : Vec (↯⁺ A) k)
       → (eval (absₙ k e) ρ %ₙ as) ≡ eval e (as ++ ρ)
-    abs-βₙ ρ [] = refl
-    abs-βₙ {e = e} ρ (x ∷ as) = ap (_% x .fst) (abs-βₙ ρ as) ∙ abs-β _ (as ++ ρ) x ∙ eval-inst e x (as ++ ρ)
+    abs-βₙ {e = e} ρ v with vec-view v
+    ... | [] = refl
+    ... | (x ∷ as) = ap (_% x .fst) (abs-βₙ ρ as)
+      ∙ abs-β _ (as ++ ρ) x
+      ∙ eval-inst e x (as ++ ρ)
 ```
 
 </details>

--- a/src/Realisability/PCA/Fixpoint.lagda.md
+++ b/src/Realisability/PCA/Fixpoint.lagda.md
@@ -52,7 +52,7 @@ We introduce an intermediate combinator `` `X ``{.Agda}, and define
 `Z : ↯⁺ 𝔸
 `Z = record
   { fst = `X ⋆ `X
-  ; snd = subst ⌞_⌟ (sym (abs-βₙ [] (`X ∷ []))) (abs↓ _ _)
+  ; snd = subst ⌞_⌟ (sym (abs-βₙ []v (`X ∷v []v))) (abs↓ _ _)
   }
 ```
 
@@ -61,11 +61,11 @@ This lets us prove the desired properties of `` `Z ``{.Agda}.
 ```agda
 abstract
   `Z↓₁ : ⌞ x ⌟ → ⌞ `Z ⋆ x ⌟
-  `Z↓₁ {x} xh = subst ⌞_⌟ (sym (abs-βₙ [] ((x , xh) ∷ `X ∷ []))) (abs↓ _ _)
+  `Z↓₁ {x} xh = subst ⌞_⌟ (sym (abs-βₙ []v ((x , xh) ∷v `X ∷v []v))) (abs↓ _ _)
 
   `Z-β : ⌞ x ⌟ → ⌞ y ⌟ → `Z ⋆ x ⋆ y ≡ x ⋆ (`Z ⋆ x) ⋆ y
   `Z-β {x} {y} xh yh =
-    `X ⋆ `X ⋆ x ⋆ y        ≡⟨ abs-βₙ [] ((y , yh) ∷ (x , xh) ∷ `X ∷ []) ⟩
+    `X ⋆ `X ⋆ x ⋆ y        ≡⟨ abs-βₙ []v ((y , yh) ∷v (x , xh) ∷v `X ∷v []v) ⟩
     x ⋆ (`X ⋆ `X ⋆ x) ⋆ y  ≡⟨⟩
     x ⋆ (`Z ⋆ x) ⋆ y       ∎
 ```

--- a/src/Realisability/PCA/Sugar.lagda.md
+++ b/src/Realisability/PCA/Sugar.lagda.md
@@ -120,20 +120,20 @@ instead.
 
 ```agda
 expr_ : (t : ∀ {V} → Termʰ V) ⦃ _ : wf 0 t ⦄ → ↯ ⌞ 𝔸 ⌟
-expr_ t ⦃ i ⦄ = eval {n = 0} (from-wf t i) []
+expr_ t ⦃ i ⦄ = eval {n = 0} (from-wf t i) []v
 
 val_
   : (t : ∀ {V} → Termʰ V) ⦃ _ : wf 0 t ⦄
   → ⦃ _ : always-denotes {Nat} t ⦄ → ↯⁺ ⌞ 𝔸 ⌟
 val_ t ⦃ i ⦄ =
   record
-    { fst = eval {n = 0} (from-wf t i) []
+    { fst = eval {n = 0} (from-wf t i) []v
     ; snd = d t
     }
   where abstract
-  d : (t : Termʰ Nat) ⦃ i : wf 0 t ⦄ ⦃ _ : always-denotes t ⦄ → ⌞ eval {n = 0} (from-wf t i) [] ⌟
+  d : (t : Termʰ Nat) ⦃ i : wf 0 t ⦄ ⦃ _ : always-denotes t ⦄ → ⌞ eval {n = 0} (from-wf t i) []v ⌟
   d (const x) = x .snd
-  d (lam x) = abs↓ (from-wf (x 0) _) []
+  d (lam x) = abs↓ (from-wf (x 0) _) []v
 ```
 
 Finally, we introduce a notation class `To-term`{.Agda} to overload the


### PR DESCRIPTION
resolves: #567

# Description

As per a suggestion by @TOTBWF, this changes `Data.Vec` to use a refinement type which codes `length xs = n`.

Unfortunately this means that induction on vecs now needs `vec-view`, which makes some things messier. Worse still, I can't seem to use `[]` as a pattern for the empty vec since it conflicts with list, and use `∷` at all since it can't be a pattern.

The order of instances is also changed a little bit, which means `[ p ]` fails to realize as a list in `1Lab.Reflection.List`.

I'd love some tips on how to make this a little bit cleaner :)

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.