### PR TITLE
decidable/discrete/strongly total orders are the same

### DIFF
--- a/src/Data/Sum/Base.lagda.md
+++ b/src/Data/Sum/Base.lagda.md
@@ -56,6 +56,14 @@ infix 0 if⁺_then_else_
 if⁺_then_else_ : A ⊎ B → C → C → C
 if⁺ inl _ then y else n = y
 if⁺ inr _ then y else n = n
+
+is-right : A ⊎ B → Bool
+is-right (inl _) = false
+is-right (inr _) = true
+
+is-left : A ⊎ B → Bool
+is-left (inl _) = true
+is-left (inr _) = false
 ```
 -->
 

--- a/src/Order/Base.lagda.md
+++ b/src/Order/Base.lagda.md
@@ -302,7 +302,6 @@ _^opp : ∀ {ℓ ℓ'} → Poset ℓ ℓ' → Poset ℓ ℓ'
 We can construct the trivial posets with one and zero (object(s), ordering(s)) respectively
 
 ```agda
-
 𝟙ᵖ : ∀ {o ℓ} → Poset o ℓ
 𝟙ᵖ .Poset.Ob = Lift _ ⊤
 𝟙ᵖ .Poset._≤_ _ _ = Lift _ ⊤
@@ -319,3 +318,38 @@ We can construct the trivial posets with one and zero (object(s), ordering(s)) r
 𝟘ᵖ .Poset.≤-trans ()
 𝟘ᵖ .Poset.≤-antisym ()
 ```
+
+## Decidable partial orders {defines="decidable-partial-order"}
+
+We say that a poset is **decidable** if the ordering relation between
+any pair of elements is [[decidable]]. Note that this does *not* imply
+that the order is [[total|total order]]: for instance, the [[discrete
+partial order]] on two elements is decidable but not total.
+
+```agda
+module _ {o ℓ} (P : Poset o ℓ) where
+  open Poset P
+
+  is-decidable-poset : Type _
+  is-decidable-poset = ∀ {x y} → Dec (x ≤ y)
+```
+
+A decidable poset has decidable equality^[In other words, has a
+[[discrete]] underlying set; this should not be confused with a
+[[discrete partial order]].]: by antisymmetry, we can decide $x = y$ by
+deciding $(x ≤ y) × (y ≤ x)$.
+
+```agda
+  decidable→discrete
+    : ⦃ is-decidable-poset ⦄
+    → Discrete ⌞ P ⌟
+  decidable→discrete .decide x y with holds? (x ≤ y) | holds? (y ≤ x)
+  ... | yes x≤y | yes y≤x = yes (≤-antisym x≤y y≤x)
+  ... | yes x≤y | no ¬y≤x = no λ x=y → ¬y≤x (≤-refl' (sym x=y))
+  ... | no ¬x≤y | _       = no λ x=y → ¬x≤y (≤-refl' x=y)
+```
+
+The converse is not true: given a proposition $P$, the poset with two
+elements $\{a, b\}$ such that $a ≤ b$ iff $P$ holds always has decidable
+equality, but is decidable if and only if $P$ is. However, a discrete
+[[*total* order]] is always decidable (see there).

--- a/src/Order/Total.lagda.md
+++ b/src/Order/Total.lagda.md
@@ -5,6 +5,9 @@ open import 1Lab.Prelude
 open import Data.Dec
 open import Data.Sum
 
+open import Homotopy.Pushout
+open import Homotopy.Join
+
 open import Order.Diagram.Join
 open import Order.Diagram.Meet
 open import Order.Base
@@ -32,8 +35,19 @@ record is-total-order {o ℓ} (P : Poset o ℓ) : Type (o ⊔ ℓ) where
   open Poset P public
 
   field
-    compare         : ∀ x y → (x ≤ y) ⊎ (y ≤ x)
+    compare : ∀ x y → (x ≤ y) ∗ (y ≤ x)
 ```
+
+<!--
+```agda
+private unquoteDecl is-total-order-eqv = declare-record-iso is-total-order-eqv (quote is-total-order)
+
+instance
+  H-Level-is-total-order : ∀ {o ℓ} {P : Poset o ℓ} {k} → H-Level (is-total-order P) (suc k)
+  H-Level-is-total-order = prop-instance (Iso→is-hlevel 1 is-total-order-eqv
+    (Π-is-hlevel² 1 λ _ _ → join-is-prop (hlevel 1) (hlevel 1)))
+```
+-->
 
 ::: note
 The _ordering_ procedure, `compare`{.Agda}, is orthogonal from having a
@@ -57,9 +71,9 @@ module minmax {o ℓ} {P : Poset o ℓ} (to : is-total-order P) where
 
 ```agda
   min : (x y : ⌞ P ⌟) → ⌞ P ⌟
-  min x y with compare x y
-  ... | inl p = x
-  ... | inr q = y
+  min x y = worker (compare x y) module min where
+    worker = Pushout-elim (λ _ → x) (λ _ → y)
+      (λ (x≤y , y≤x) → ≤-antisym x≤y y≤x)
 ```
 
 The proofs that this is actually the meet of $x$ and $y$ proceed by
@@ -68,19 +82,19 @@ doing the comparison again: this "unblocks" the computation of $\min$.
 ```agda
   abstract
     min-≤l : ∀ x y → min x y ≤ x
-    min-≤l x y with compare x y
-    ... | inl p = ≤-refl
-    ... | inr q = q
+    min-≤l x y = join-elim-prop
+      {P = λ p → min.worker x y p ≤ x} (λ _ → hlevel 1)
+      (λ _ → ≤-refl) (λ q → q) (compare x y)
 
     min-≤r : ∀ x y → min x y ≤ y
-    min-≤r x y with compare x y
-    ... | inl p = p
-    ... | inr q = ≤-refl
+    min-≤r x y = join-elim-prop
+      {P = λ p → min.worker x y p ≤ y} (λ _ → hlevel 1)
+      (λ p → p) (λ _ → ≤-refl) (compare x y)
 
     min-univ : ∀ x y z → z ≤ x → z ≤ y → z ≤ min x y
-    min-univ x y z p q with compare x y
-    ... | inl _ = p
-    ... | inr _ = q
+    min-univ x y z p q = join-elim-prop
+      {P = λ p → z ≤ min.worker x y p} (λ _ → hlevel 1)
+      (λ _ → p) (λ _ → q) (compare x y)
 ```
 
 This is everything we need to prove that we have our hands on a meet.
@@ -97,24 +111,25 @@ further commentary.
 
 ```agda
   max : (x y : ⌞ P ⌟) → ⌞ P ⌟
-  max x y with compare x y
-  ... | inl p = y
-  ... | inr q = x
+  max x y = worker (compare x y) module max where
+    worker = Pushout-elim (λ _ → y) (λ _ → x)
+      (λ (x≤y , y≤x) → ≤-antisym y≤x x≤y)
 
-  max-≤l : ∀ x y → x ≤ max x y
-  max-≤l x y with compare x y
-  ... | inl p = p
-  ... | inr q = ≤-refl
+  abstract
+    max-≤l : ∀ x y → x ≤ max x y
+    max-≤l x y = join-elim-prop
+      {P = λ p → x ≤ max.worker x y p} (λ _ → hlevel 1)
+      (λ p → p) (λ _ → ≤-refl) (compare x y)
 
-  max-≤r : ∀ x y → y ≤ max x y
-  max-≤r x y with compare x y
-  ... | inl p = ≤-refl
-  ... | inr q = q
+    max-≤r : ∀ x y → y ≤ max x y
+    max-≤r x y = join-elim-prop
+      {P = λ p → y ≤ max.worker x y p} (λ _ → hlevel 1)
+      (λ _ → ≤-refl) (λ q → q) (compare x y)
 
-  max-univ : ∀ x y z → x ≤ z → y ≤ z → max x y ≤ z
-  max-univ x y z p q with compare x y
-  ... | inl _ = q
-  ... | inr _ = p
+    max-univ : ∀ x y z → x ≤ z → y ≤ z → max x y ≤ z
+    max-univ x y z p q = join-elim-prop
+      {P = λ p → max.worker x y p ≤ z} (λ _ → hlevel 1)
+      (λ _ → q) (λ _ → p) (compare x y)
 
   max-is-join : ∀ x y → is-join P x y (max x y)
   max-is-join x y .l≤join = max-≤l x y
@@ -180,9 +195,8 @@ which we refer to as **weak totality**.
 <!--
 ```agda
   from-not-≤ : ∀ {x y} → ¬ (x ≤ y) → y ≤ x
-  from-not-≤ {x} {y} ¬x≤y with compare x y
-  ... | inl x≤y = absurd (¬x≤y x≤y)
-  ... | inr y≤x = y≤x
+  from-not-≤ {x} {y} ¬x≤y = join-elim-prop (λ _ → hlevel 1)
+    (λ x≤y → absurd (¬x≤y x≤y)) (λ y≤x → y≤x) (compare x y)
 
 module _ {o ℓ} {P : Poset o ℓ} ⦃ _ : Discrete ⌞ P ⌟ ⦄ ⦃ _ : is-decidable-poset P ⦄ where
   open Poset P
@@ -201,7 +215,7 @@ if it holds, we're done; Otherwise, weak totality lets us conclude that
 $y \le x$ from the computed witness of $x \not\le y$.
 
 ```agda
-    compare : ∀ x y → (x ≤ y) ⊎ (y ≤ x)
+    compare : ∀ x y → (x ≤ y) ∗ (y ≤ x)
     compare x y with holds? (x ≤ y)
     ... | yes x≤y = inl x≤y
     ... | no ¬x≤y = inr (wk ¬x≤y)

--- a/src/Order/Total.lagda.md
+++ b/src/Order/Total.lagda.md
@@ -2,11 +2,16 @@
 ```agda
 open import 1Lab.Prelude
 
+open import Data.Bool
 open import Data.Dec
 open import Data.Sum
 
+open import Homotopy.Space.Suspension.Properties
+open import Homotopy.Space.Suspension
 open import Homotopy.Pushout
 open import Homotopy.Join
+
+open import Meta.Invariant
 
 open import Order.Diagram.Join
 open import Order.Diagram.Meet
@@ -28,7 +33,10 @@ open is-meet
 # Total orders {defines="total-order"}
 
 A **total order** is a [[partial order]] where every pair of elements
-can be compared.
+can be compared: that is, in which we have $∀ x y.\ x ≤ y ∨ y ≤ x$.
+Note the use of the [[disjunction]]: we want totality to be a proposition,
+and having the truncation on the outside of the quantifiers would
+actually yield a [[decidable total order]]!
 
 ```agda
 record is-total-order {o ℓ} (P : Poset o ℓ) : Type (o ⊔ ℓ) where
@@ -49,18 +57,11 @@ instance
 ```
 -->
 
-::: note
-The _ordering_ procedure, `compare`{.Agda}, is orthogonal from having a
-[[decision procedure|decidable]] for the order: if comparing $x, y$
-results in $x \le y$, we can not, in general, turn this into a proof of
-$y \not\le x$.
-:::
-
-Having a decision procedure for the relative order of two elements
-allows us to compute [[meets]] and [[joins]] in a very straightforward
-way: We test whether $x \le y$, and, if that's the case, then $\min(x,y)
-= x$; otherwise, $\min(x,y) = y$. The definition of $\max$ is exactly
-dual.
+Totality allows us to compute [[meets]] and [[joins]] in a very straightforward
+way: in a poset, meets and joins are propositions (by antisymmetry), so we
+can reason by cases. We test whether $x \le y$, and, if that's the case,
+then $\min(x,y) = x$; otherwise, $\min(x,y) = y$. The definition of
+$\max$ is exactly dual.
 
 <!--
 ```agda
@@ -139,48 +140,26 @@ further commentary.
 
 ## Decidable total orders {defines="decidable-total-order"}
 
-In particularly nice cases, we can not only decide the relative position
-of a pair of elements, but whether a pair of elements is related at all:
-this is a **decidable total order**.
-
-<!--
-```agda
-is-decidable-poset : ∀ {o ℓ} (P : Poset o ℓ) → Type _
-is-decidable-poset P = ∀ {x y} → Dec (x ≤ y)
-  where open Poset P
-```
--->
+A total order that is also a [[decidable partial order]] is called a
+**decidable total order**.
 
 ```agda
 record is-decidable-total-order {o ℓ} (P : Poset o ℓ) : Type (o ⊔ ℓ) where
   field
     has-is-total : is-total-order P
+    ⦃ dec-≤ ⦄    : is-decidable-poset P
 
   open is-total-order has-is-total public
 ```
 
-As the name implies, a decidable total order must be a total order; and
-it must also be decidable:
+Every decidable poset has decidable equality (see
+`decidable→discrete`{.Agda}), but we include this as a redundant field
+for formalisation reasons --- allowing the user to specify a more
+efficient decision procedure for equality.
 
 ```agda
   field
-    ⦃ dec-≤    ⦄ : is-decidable-poset P
     ⦃ discrete ⦄ : Discrete ⌞ P ⌟
-```
-
-Note that we have included a requirement that a decidable total order be
-[[discrete]], i.e., that its equality is also decidable. This is purely
-for formalisation reasons --- allowing the user to specify a more
-efficient decision procedure for equality ---, since we can use the
-decidable ordering to decide equality.
-
-```agda
-  private
-    was-discrete-anyways : Discrete ⌞ P ⌟
-    was-discrete-anyways .decide x y with holds? (x ≤ y) | holds? (y ≤ x)
-    ... | yes x≤y | yes y≤x = yes (≤-antisym x≤y y≤x)
-    ... | yes x≤y | no ¬y≤x = no λ x=y → ¬y≤x (≤-refl' (sym x=y))
-    ... | no ¬x≤y | _       = no λ x=y → ¬x≤y (≤-refl' x=y)
 ```
 
 Note that, if we have a decidable order, then the requirement of
@@ -197,6 +176,14 @@ which we refer to as **weak totality**.
   from-not-≤ : ∀ {x y} → ¬ (x ≤ y) → y ≤ x
   from-not-≤ {x} {y} ¬x≤y = join-elim-prop (λ _ → hlevel 1)
     (λ x≤y → absurd (¬x≤y x≤y)) (λ y≤x → y≤x) (compare x y)
+
+unquoteDecl H-Level-is-decidable-total-order =
+  declare-record-hlevel 1 H-Level-is-decidable-total-order (quote is-decidable-total-order)
+
+module _ {o ℓ} (P : Poset o ℓ) (t : is-total-order P) (d : is-decidable-poset P) where
+  mk-decidable-total-order : is-decidable-total-order P
+  mk-decidable-total-order =
+    record { has-is-total = t; dec-≤ = d; discrete = decidable→discrete P ⦃ d ⦄ }
 
 module _ {o ℓ} {P : Poset o ℓ} ⦃ _ : Discrete ⌞ P ⌟ ⦄ ⦃ _ : is-decidable-poset P ⦄ where
   open Poset P
@@ -222,4 +209,185 @@ $y \le x$ from the computed witness of $x \not\le y$.
 
     tot : is-total-order P
     tot = record { compare = compare }
+```
+
+### As discrete total orders
+
+We now turn to some surprising restatements of the property of being a
+decidable total order. For the purposes of this page, let's call a
+partial order **strongly total** if there exists a function
+with the type $∀ x y.\ x ≤ y ⊎ y ≤ x$: we remove the truncation from the
+definition of a total order.^[Note that `is-strongly-total` is not a
+proposition, since it carries at least a bit of data for each element.
+The actual property it refers to is the *mere* existence of such a
+function, but it is more convenient to talk about the untruncated
+version.]
+
+```agda
+module _ {o ℓ} (P : Poset o ℓ) where
+  open Poset P
+
+  is-strongly-total : Type (o ⊔ ℓ)
+  is-strongly-total = ∀ x y → x ≤ y ⊎ y ≤ x
+
+  strongly-total→total : is-strongly-total → is-total-order P
+  strongly-total→total st =
+    record { compare = λ x y → [ inl , inr ] (st x y) }
+```
+
+We then have that *decidable* total orders, *discrete* total
+orders,^[That is, total orders with decidable equality.] and *strong*
+total orders are all the same thing! We already know that every
+decidable total order is discrete, so we have to show that discrete
+total orders are strong and that strong total orders are decidable.
+
+For the first step, we proceed by cases: if $x = y$, then we can pick
+either branch arbitrarily by reflexivity. Otherwise, we note that
+$x ≤ y$ and $y ≤ x$ are *mutually exclusive* propositions by
+antisymmetry, so their disjunction is already a proposition and we can
+safely get rid of the truncation.
+
+```agda
+  discrete-total→strong : is-total-order P → Discrete ⌞ P ⌟ → is-strongly-total
+  discrete-total→strong total d x y with d .decide x y
+  ... | yes p = inl (≤-refl' p)
+  ... | no ¬p = join-elim-prop
+    (λ _ → disjoint-⊎-is-prop ≤-thin ≤-thin λ (x≤y , y≤x) → ¬p (≤-antisym x≤y y≤x))
+    inl inr
+    (compare x y)
+    where open is-total-order total using (compare)
+```
+
+The fact that strong total orders are decidable is slightly more subtle:
+in order to decide whether $x ≤ y$ or not, we proceed by cases on the
+result of comparing the two pairs $(x, y)$ and $(y, x)$. If either of
+those comparisons results in $x ≤ y$, then we can answer positively;
+otherwise we have $y ≤ x$, and we observe that the first comparison must
+have returned `inr` while the second must have returned `inl`. We thus
+answer *negatively*: if we had $x ≤ y$, then by antisymmetry we would
+have $x = y$, hence the two pairs would have yielded the same result.
+
+```agda
+  strong→decidable : is-strongly-total → is-decidable-poset P
+  strong→decidable st {x} {y} with st x y in e₁ | st y x in e₂
+  ... | inl x≤y | _       = yes x≤y
+  ... | inr y≤x | inr x≤y = yes x≤y
+  ... | inr y≤x | inl _   = no λ x≤y → true≠false $
+    let p = ≤-antisym x≤y y≤x in
+    true              ≡˘⟨ ap is-right (Id≃path.to e₁) ⟩
+    is-right (st x y) ≡⟨ ap₂ (λ x y → is-right (st x y)) p (sym p) ⟩
+    is-right (st y x) ≡⟨ ap is-right (Id≃path.to e₂) ⟩
+    false             ∎
+```
+
+Thus all three properties are equivalent.
+
+```agda
+  strong→decidable-total
+    : ∥ is-strongly-total ∥ → is-decidable-total-order P
+  strong→decidable-total = rec! λ st →
+    mk-decidable-total-order P (strongly-total→total st) (strong→decidable st)
+
+  decidable-total→strong
+    : is-total-order P → is-decidable-poset P → is-strongly-total
+  decidable-total→strong total d =
+    discrete-total→strong total (decidable→discrete P ⦃ d ⦄)
+
+  discrete-total→decidable
+    : is-total-order P → Discrete ⌞ P ⌟ → is-decidable-total-order P
+  discrete-total→decidable total d =
+    strong→decidable-total (inc (discrete-total→strong total d))
+```
+
+### A counterexample
+
+We give a (Brouwerian) example of an undecidable total order: given a
+proposition $P$, we construct a total order that if decidable if and
+only if $P$ is.
+
+The underlying set is the [[suspension]] of $P$, $\Susp{P}$.
+
+```agda
+module Latitude {ℓ} (P : Type ℓ) (P-prop : is-prop P) where
+  ΣP = Susp P
+
+  ΣP-is-set : is-set ΣP
+  ΣP-is-set = Susp-prop-is-set P-prop
+```
+
+By declaring that the north pole is higher than the south pole, we
+obtain a total order on $\Susp{P}$: we have $\mathsf{south} ≤
+\mathsf{north}$ always, thus by antisymmetry $\mathsf{north} ≤
+\mathsf{south}$ if and only if $P$.
+
+```agda
+  _≤_ : ΣP → ΣP → Prop ℓ
+  _≤_ = Susp-elim _
+    (Susp-elim _
+      (el! (Lift _ ⊤)) -- N ≤ N
+      (el P P-prop)    -- N ≤ S
+      (λ p → n-ua (P→⊤≃P p)))
+    (λ _ → el! (Lift _ ⊤)) -- S ≤ _
+    (λ p → ext (Susp-elim-prop (λ _ → hlevel 1) refl (n-ua (P→⊤≃P p e⁻¹))))
+    where
+      P→⊤≃P : P → Lift _ ⊤ ≃ P
+      P→⊤≃P p = is-contr→≃ (hlevel 0) (is-prop∙→is-contr P-prop p)
+```
+
+<details>
+<summary>
+It is straightforward but tedious to show that this is a total
+order, so we omit the proofs.
+
+```agda
+  Latitude : Poset ℓ ℓ
+  Latitude-total : is-total-order Latitude
+```
+</summary>
+
+```agda
+  ≤-refl : ∀ x → ∣ x ≤ x ∣
+  ≤-refl = Susp-elim-prop (λ _ → hlevel 1) _ _
+
+  ≤-trans : ∀ x y z → ∣ x ≤ y ∣ → ∣ y ≤ z ∣ → ∣ x ≤ z ∣
+  ≤-trans = Susp-elim-prop (λ _ → hlevel 1)
+    (Susp-elim-prop (λ _ → hlevel 1)
+      (λ _ _ p → p)
+      (Susp-elim-prop (λ _ → hlevel 1)
+        _
+        (λ p _ → p)))
+    _
+
+  ≤-antisym : ∀ x y → ∣ x ≤ y ∣ → ∣ y ≤ x ∣ → x ≡ y
+  ≤-antisym = Susp-elim-prop
+    (λ _ → Π-is-hlevel 1 λ _ → Π-is-hlevel² 1 λ _ _ → ΣP-is-set _ _)
+    (Susp-elim-prop (λ _ → Π-is-hlevel² 1 λ _ _ → ΣP-is-set _ _)
+      (λ _ _ → refl)
+      (λ p _ → merid p))
+    (Susp-elim-prop (λ _ → Π-is-hlevel² 1 λ _ _ → ΣP-is-set _ _)
+      (λ _ p → sym (merid p))
+      (λ _ _ → refl))
+
+  Latitude .Poset.Ob = ΣP
+  Latitude .Poset._≤_ x y = ∣ x ≤ y ∣
+  Latitude .Poset.≤-thin {x} {y} = (x ≤ y) .is-tr
+  Latitude .Poset.≤-refl {x} = ≤-refl x
+  Latitude .Poset.≤-trans {x} {y} {z} = ≤-trans x y z
+  Latitude .Poset.≤-antisym {x} {y} = ≤-antisym x y
+
+  Latitude-total .is-total-order.compare = Susp-elim-prop
+    (λ _ → Π-is-hlevel 1 λ _ → join-is-prop (hlevel 1) (hlevel 1))
+    (Susp-elim-prop (λ _ → join-is-prop (hlevel 1) (hlevel 1))
+      (inl _)
+      (inr _))
+    (λ _ → inl _)
+```
+</details>
+
+By construction, this is a decidable order if and only if we can decide
+$\mathsf{north} ≤ \mathsf{south}$, i.e. $P$.
+
+```agda
+  Latitude-decidable→P-decidable : is-decidable-poset Latitude → Dec P
+  Latitude-decidable→P-decidable d = d {north} {south}
 ```


### PR DESCRIPTION
The first commit fixes https://github.com/the1lab/1lab/issues/474 by using join instead of sum in `is-total-order`. (This turned out to be more convenient than truncating.)

The second commit shows that decidable total orders, total orders with decidable equality, and our previous definition of total order (now renamed to *strong* total order) are in fact all equivalent!