### PR TITLE
chore: Add records for directly consuming (co)limits

### DIFF
--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -149,6 +149,14 @@ morphism:
       → ∀ {o2} → (∀ j → o2 C.∘ ψ j ≡ eta j)
       → o1 ≡ o2
     unique₂ eta p q r = unique eta p _ q ∙ sym (unique eta p _ r)
+
+  record Make-colimit (Diagram : Functor J C) : Type (o₁ ⊔ h₁ ⊔ o₂ ⊔ h₂) where
+    no-eta-equality
+    field
+      coapex : C.Ob
+      has-colimit : make-is-colimit Diagram coapex
+
+    open make-is-colimit has-colimit public
 ```
 -->
 
@@ -276,6 +284,18 @@ function which **un**makes a colimit.
   to-colimit c .Lan.Ext = _
   to-colimit c .Lan.eta = _
   to-colimit c .Lan.has-lan = c
+
+  to-make-colimit
+    : {D : Functor J C} {coapex : C.Ob} → make-is-colimit D coapex → Make-colimit D
+  to-make-colimit mc .Make-colimit.coapex      = _
+  to-make-colimit mc .Make-colimit.has-colimit = mc
+
+  Colimit→Make-colimit : {D : Functor J C} → Colimit D → Make-colimit D
+  Colimit→Make-colimit colim = to-make-colimit $ unmake-colimit $ Lan.has-lan colim
+
+  Make-colimit→Colimit : {D : Functor J C} → Make-colimit D → Colimit D
+  Make-colimit→Colimit colim =
+    to-colimit $ to-is-colimit $ Make-colimit.has-colimit colim
 ```
 -->
 
@@ -557,6 +577,13 @@ is-cocomplete : ∀ {oc ℓc} o ℓ → Precategory oc ℓc → Type _
 is-cocomplete oj ℓj C = ∀ {J : Precategory oj ℓj} (F : Functor J C) → Colimit F
 ```
 
+<!--
+```agda
+is-cocomplete' : ∀ {oc ℓc} o ℓ → Precategory oc ℓc → Type _
+is-cocomplete' oj ℓj C = {J : Precategory oj ℓj} (F : Functor J C) → Make-colimit F
+```
+-->
+
 While this condition might sound very strong, and thus that it would be hard to come
 by, it turns out we can get away with only two fundamental types of colimits:
 [[coproducts]] and [[coequalisers]]. In order to construct the colimit for a diagram
@@ -580,9 +607,9 @@ module _ {o ℓ} {C : Precategory o ℓ} where
     → has-coproducts-indexed-by C ⌞ J ⌟
     → has-coproducts-indexed-by C (Arrow J)
     → has-coequalisers C
-    → (F : Functor J C) → Colimit F
+    → (F : Functor J C) → Make-colimit F
   colimit-as-coequaliser-of-coproduct {oj} {ℓj} {J} has-Ob-cop has-Arrow-cop has-coeq F =
-    to-colimit (to-is-colimit colim) where
+    to-make-colimit colim where
 ```
 
 <!--
@@ -677,7 +704,7 @@ all colimits.
     : ∀ {oj ℓj}
     → has-indexed-coproducts C (oj ⊔ ℓj)
     → has-coequalisers C
-    → is-cocomplete oj ℓj C
+    → is-cocomplete' oj ℓj C
   coproducts+coequalisers→cocomplete {oj} {ℓj} has-cop has-coeq =
     colimit-as-coequaliser-of-coproduct
       (λ _ → Lift-Indexed-coproduct C ℓj (has-cop _))

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -189,8 +189,9 @@ the rest of the data.
     open Functor
 
     colim : is-colimit Diagram coapex (to-cocone mkcolim)
-    colim .σ {M = M} α .η _ =
-      universal (α .η) (λ f → α .is-natural _ _ f ∙ C.eliml (M .F-id))
+    colim .σ {M = M} α .η _ = universal (α .η) comm where abstract
+      comm : ∀ {x y} (f : J.Hom x y) → α .η y C.∘ Diagram .F₁ f ≡ α .η x
+      comm f = α .is-natural _ _ f ∙ C.eliml (M .F-id)
     colim .σ {M = M} α .is-natural _ _ _ = C.idr _ ∙ C.introl (M .F-id)
     colim .σ-comm {α = α} = ext λ j → factors (α .η) _
     colim .σ-uniq {α = α} {σ' = σ'} p = ext λ _ →

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -305,8 +305,9 @@ other data we have been given:
     open _=>_
 
     lim : is-limit Diagram apex (to-cone mklim)
-    lim .σ {M = M} α .η _ =
-      universal (α .η) (λ f → sym (α .is-natural _ _ f) ∙ C.elimr (M .F-id))
+    lim .σ {M = M} α .η _ = universal (α .η) comm where abstract
+      comm : ∀ {x y} (f : J.Hom x y) → Diagram .F₁ f C.∘ α .η x ≡ α .η y
+      comm f = sym (α .is-natural _ _ f) ∙ C.elimr (M .F-id)
     lim .σ {M = M} α .is-natural _ _ _ =
       lim .σ α .η _ C.∘ M .F₁ tt ≡⟨ C.elimr (M .F-id) ⟩
       lim .σ α .η _              ≡˘⟨ C.idl _ ⟩

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -268,6 +268,14 @@ the apex by a single, _unique_ universal morphism:
       → {o2 : C.Hom x apex} → (∀ j → ψ j C.∘ o2 ≡ eps j)
       → o1 ≡ o2
     unique₂ {x = x} eps p q r = unique eps p _ q ∙ sym (unique eps p _ r)
+
+  record Make-limit (Diagram : Functor J C) : Type (o₁ ⊔ h₁ ⊔ o₂ ⊔ h₂) where
+    no-eta-equality
+    field
+      apex : C.Ob
+      has-limit : make-is-limit Diagram apex
+
+    open make-is-limit has-limit public
 ```
 -->
 
@@ -390,6 +398,17 @@ limit:
   to-limit l .Ran.Ext = _
   to-limit l .Ran.eps = _
   to-limit l .Ran.has-ran = l
+
+  to-make-limit
+    : {D : Functor J C} {apex : C.Ob} → make-is-limit D apex → Make-limit D
+  to-make-limit ml .Make-limit.apex      = _
+  to-make-limit ml .Make-limit.has-limit = ml
+
+  Limit→Make-limit : {D : Functor J C} → Limit D → Make-limit D
+  Limit→Make-limit lim = to-make-limit $ unmake-limit $ Ran.has-ran lim
+
+  Make-limit→Limit : {D : Functor J C} → Make-limit D → Limit D
+  Make-limit→Limit lim = to-limit $ to-is-limit $ Make-limit.has-limit lim
 ```
 -->
 
@@ -677,6 +696,9 @@ is-complete oj ℓj C = ∀ {J : Precategory oj ℓj} (F : Functor J C) → Limi
 
 <!--
 ```agda
+is-complete' : ∀ {oc ℓc} o ℓ → Precategory oc ℓc → Type _
+is-complete' oj ℓj C = {J : Precategory oj ℓj} (F : Functor J C) → Make-limit F
+
 is-complete-lower
   : ∀ {o ℓ} {C : Precategory o ℓ} o₁ ℓ₁ o₂ ℓ₂
   → is-complete (o₁ ⊔ o₂) (ℓ₁ ⊔ ℓ₂) C
@@ -718,9 +740,9 @@ module _ {o ℓ} {C : Precategory o ℓ} where
     → has-products-indexed-by C ⌞ J ⌟
     → has-products-indexed-by C (Arrow J)
     → has-equalisers C
-    → (F : Functor J C) → Limit F
+    → (F : Functor J C) → Make-limit F
   limit-as-equaliser-of-product {oj} {ℓj} {J} has-Ob-prod has-Arrow-prod has-eq F =
-    to-limit (to-is-limit lim) where
+    to-make-limit lim where
 ```
 
 <!--
@@ -814,7 +836,7 @@ all limits.
     : ∀ {oj ℓj}
     → has-indexed-products C (oj ⊔ ℓj)
     → has-equalisers C
-    → is-complete oj ℓj C
+    → is-complete' oj ℓj C
   products+equalisers→complete {oj} {ℓj} has-prod has-eq =
     limit-as-equaliser-of-product
       (λ _ → Lift-Indexed-product C ℓj (has-prod _))

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -97,7 +97,7 @@ products).
     : is-category C
     → Finitely-complete → is-finitely-complete
   Finitely-complete→is-finitely-complete cat Flim finite =
-    limit-as-equaliser-of-product
+    Make-limit→Limit ⊙ limit-as-equaliser-of-product
       (Cartesian→finite-products (Flim .terminal) (Flim .products) cat (finite .has-finite-Ob))
       (Cartesian→finite-products (Flim .terminal) (Flim .products) cat (finite .has-finite-Arrow))
       (Flim .equalisers)

--- a/src/Cat/Functor/Hom/Cocompletion.lagda.md
+++ b/src/Cat/Functor/Hom/Cocompletion.lagda.md
@@ -15,7 +15,7 @@ open import Cat.Prelude
 module
   Cat.Functor.Hom.Cocompletion
     {κ o} (C : Precategory κ κ) (D : Precategory o κ)
-    (colim : is-cocomplete κ κ D)
+    (colim : is-cocomplete' κ κ D)
     where
 ```
 

--- a/src/Cat/Functor/Kan/Nerve.lagda.md
+++ b/src/Cat/Functor/Kan/Nerve.lagda.md
@@ -183,7 +183,7 @@ computations using naturality. It's not very enlightening.
 module _
   {o κ κ'} {C : Precategory κ κ} {D : Precategory o κ'}
   (F : Functor C D)
-  (cocompl : is-cocomplete κ κ D)
+  (cocompl : is-cocomplete' κ κ D)
   where
 ```
 -->
@@ -209,7 +209,7 @@ left adjoint we were after, the "realisation" functor.
 module _
   {o κ} {C : Precategory κ κ} {D : Precategory o κ}
   (F : Functor C D)
-  (cocompl : is-cocomplete κ κ D)
+  (cocompl : is-cocomplete' κ κ D)
   where
 
   private

--- a/src/Cat/Functor/Kan/Pointwise.lagda.md
+++ b/src/Cat/Functor/Kan/Pointwise.lagda.md
@@ -192,10 +192,10 @@ having colimits of these comma-category-shaped diagrams.
 
 ```agda
   comma-colimits→lan
-    : (∀ (c' : C'.Ob) → Colimit (↓Dia c'))
+    : (∀ (c' : C'.Ob) → Make-colimit (↓Dia c'))
     → Lan F G
   comma-colimits→lan ↓colim = lan module comma-colimits→lan where
-      module ↓colim c' = Colimit (↓colim c')
+      module ↓colim c' = Make-colimit (↓colim c')
 ```
 
 Taking the colimit at each $c' : \cC'$ gives an assignment of objects
@@ -304,8 +304,8 @@ And, if $\cD$ is $\kappa$-cocomplete, then it certainly has the required
 colimits: we can "un-weaken" our result.
 
 ```agda
-  cocomplete→lan : is-cocomplete (o'' ⊔ ℓ) ℓ D → Lan F G
-  cocomplete→lan colimits = comma-colimits→lan (λ c' → colimits (↓Dia c'))
+  cocomplete→lan : is-cocomplete' (o'' ⊔ ℓ) ℓ D → Lan F G
+  cocomplete→lan colimits = comma-colimits→lan λ c' → colimits (↓Dia c')
 ```
 
 
@@ -343,7 +343,7 @@ end up being off by a bunch of natural isomorphisms.
 ```agda
   preserves-colimits→preserves-pointwise-lan
     : ∀ {o'' ℓ''} {E : Precategory o'' ℓ''}
-    → (colimits : is-cocomplete ℓ ℓ D)
+    → (colimits : is-cocomplete' ℓ ℓ D)
     → (H : Functor D E)
     → is-cocontinuous ℓ ℓ H
     → preserves-is-lan H (Lan.has-lan (cocomplete→lan F G colimits))
@@ -355,17 +355,19 @@ end up being off by a bunch of natural isomorphisms.
       open make-natural-iso
       open Func
 
-      ↓colim : (c' : C'.Ob) → Colimit (G F∘ Dom F (!Const c'))
+      ↓colim : (c' : C'.Ob) → Make-colimit (G F∘ Dom F (!Const c'))
       ↓colim c' = colimits (G F∘ Dom F (!Const c'))
 
-      module ↓colim c' = Colimit (↓colim c')
+      module ↓colim c' = Make-colimit (↓colim c')
 
-      H-↓colim : (c' : C'.Ob) → Colimit ((H F∘ G) F∘ Dom F (!Const c'))
+      H-↓colim : (c' : C'.Ob) → Make-colimit ((H F∘ G) F∘ Dom F (!Const c'))
       H-↓colim c' =
+        Colimit→Make-colimit $
         natural-iso→colimit ni-assoc $
-        preserves-colimit.colimit cocont (↓colim c')
+        preserves-colimit.colimit cocont $
+        Make-colimit→Colimit $ ↓colim c'
 
-      module H-↓colim c' = Colimit (H-↓colim c')
+      module H-↓colim c' = Make-colimit (H-↓colim c')
 ```
 
 <details>
@@ -417,7 +419,7 @@ words, the extension we constructed is pointwise.
 
 ```agda
   cocomplete→pointwise-lan
-    : (colim : is-cocomplete ℓ ℓ D)
+    : (colim : is-cocomplete' ℓ ℓ D)
     → is-pointwise-lan (Lan.has-lan (cocomplete→lan F G colim))
   cocomplete→pointwise-lan colim d =
     preserves-colimits→preserves-pointwise-lan
@@ -619,7 +621,7 @@ module _
   -- We don't use 'ff→pointwise-lan-ext' here, as it has a more restrictive
   -- universe bound.
   ff→cocomplete-lan-ext
-    : (cocompl : is-cocomplete ℓ ℓ D)
+    : (cocompl : is-cocomplete' ℓ ℓ D)
     → is-fully-faithful F
     → cocomplete→lan F G cocompl .Ext F∘ F ≅ⁿ G
   ff→cocomplete-lan-ext cocompl ff = (to-natural-iso ni) ni⁻¹ where

--- a/src/Cat/Instances/Functor/Limits.lagda.md
+++ b/src/Cat/Instances/Functor/Limits.lagda.md
@@ -30,7 +30,7 @@ module _
   {o₁ ℓ₁} {C : Precategory o₁ ℓ₁}
   {o₂ ℓ₂} {D : Precategory o₂ ℓ₂}
   {o₃ ℓ₃} {E : Precategory o₃ ℓ₃}
-  (has-D-lims : (F : Functor D C) → Limit F)
+  (has-D-lims : (F : Functor D C) → Make-limit F)
   (F : Functor D Cat[ E , C ])
   where
 ```
@@ -59,7 +59,7 @@ limits.
 
 ```agda
     module F' = Bifunctor F
-    module D-lim x = Limit (has-D-lims (F'.Left x))
+    module D-lim x = Make-limit (has-D-lims (F'.Left x))
 ```
 
 Let us call the limit of $F(-, x)$ --- taken in $\cC$ ---
@@ -81,8 +81,8 @@ homomorphism $K \to \lim F(-, x)$ will be called `!-for`{.Agda}.
       ∙ C.pullr (D-lim.factors _ _ _)
       ∙ C.pulll (sym (F'.rmap-∘ _ _))
 
-  functor-limit : Limit F
-  functor-limit = to-limit $ to-is-limit ml where
+  functor-limit : Make-limit F
+  functor-limit = to-make-limit ml where
     open make-is-limit
 
     ml : make-is-limit F functor-apex
@@ -106,14 +106,20 @@ As a corollary, if $\cD$ is an $(o,\ell)$-complete category, then so
 is $[\cC,\cD]$.
 
 ```agda
-Functor-cat-is-complete :
+Functor-cat-is-complete' :
   ∀ {o ℓ} {o₁ ℓ₁} {C : Precategory o₁ ℓ₁} {o₂ ℓ₂} {D : Precategory o₂ ℓ₂}
-  → is-complete o ℓ D → is-complete o ℓ Cat[ C , D ]
-Functor-cat-is-complete D-complete = functor-limit D-complete
+  → is-complete' o ℓ D → is-complete' o ℓ Cat[ C , D ]
+Functor-cat-is-complete' D-complete = functor-limit D-complete
 ```
 
 <!--
 ```agda
+Functor-cat-is-complete :
+  ∀ {o ℓ} {o₁ ℓ₁} {C : Precategory o₁ ℓ₁} {o₂ ℓ₂} {D : Precategory o₂ ℓ₂}
+  → is-complete o ℓ D → is-complete o ℓ Cat[ C , D ]
+Functor-cat-is-complete D-complete =
+  Make-limit→Limit ⊙ functor-limit (Limit→Make-limit ⊙ D-complete)
+
 module _
   {o₁ ℓ₁} {C : Precategory o₁ ℓ₁}
   {o₂ ℓ₂} {D : Precategory o₂ ℓ₂}
@@ -128,9 +134,10 @@ module _
     F' = op-functor→ F∘ Functor.op F
 
     F'-lim : Limit F'
-    F'-lim = functor-limit
-      (λ f → subst Limit (Functor-path (λ _ → refl) (λ _ → refl))
-        (Colimit→Co-limit (has-D-colims (unopF f))))
+    F'-lim = Make-limit→Limit $ functor-limit
+      (λ f → Limit→Make-limit
+        $ subst Limit (Functor-path (λ _ → refl) (λ _ → refl))
+        $ Colimit→Co-limit (has-D-colims (unopF f)))
       F'
 
     LF'' : Limit (op-functor← F∘ (op-functor→ F∘ Functor.op F))

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -10,6 +10,7 @@ open import Cat.Diagram.Initial
 open import Cat.Diagram.Pushout
 open import Cat.Prelude
 
+open import Data.Set.Coequaliser
 open import Data.Sum
 ```
 -->
@@ -124,10 +125,11 @@ definition.
     : ∀ {A : Set (ι ⊔ κ ⊔ o)} (eta : ∀ j → F ʻ j → ∣ A ∣)
     → (∀ {x y} (f : D.Hom x y) → ∀ Fx → eta y (F.F₁ f Fx) ≡ eta x Fx)
     → sum / rel → ∣ A ∣
-  univ {A} eta p =
-    Coeq-rec
-      (λ { (x , p) → eta x p })
-      (λ { ((X , x) , (Y , y) , f , q) → sym (p f x) ∙ ap (eta _) q})
+  univ {A} eta p = Coeq-rec (uncurry eta) resp where
+    open Quot
+    abstract
+      resp : ∀ (x : tot rel) → uncurry eta (/-left x) ≡ uncurry eta (/-right x)
+      resp ((X , x) , (Y , y) , f , q) = sym (p f x) ∙ ap (eta _) q
 
   colim : make-is-colimit F (el! (sum / rel))
   colim .ψ x p = inc (x , p)

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -93,8 +93,8 @@ set-coequalisers already includes a truncation.
 [coequaliser]: Data.Set.Coequaliser.html
 
 ```agda
-Sets-is-cocomplete : ∀ {ι κ o} → is-cocomplete ι κ (Sets (ι ⊔ κ ⊔ o))
-Sets-is-cocomplete {ι} {κ} {o} {J = D} F = to-colimit (to-is-colimit colim) where
+Sets-is-cocomplete' : ∀ {ι κ o} → is-cocomplete' ι κ (Sets (ι ⊔ κ ⊔ o))
+Sets-is-cocomplete' {ι} {κ} {o} {J = D} F = to-make-colimit colim where
   module D = Precategory D
   module F = Functor F
   open _=>_
@@ -140,6 +140,13 @@ definition.
       (λ x → happly (q (x .fst)) (x .snd))
       x
 ```
+
+<!--
+```agda
+Sets-is-cocomplete : ∀ {ι κ o} → is-cocomplete ι κ (Sets (ι ⊔ κ ⊔ o))
+Sets-is-cocomplete {o = o} = Make-colimit→Colimit ⊙ Sets-is-cocomplete' {o = o}
+```
+-->
 
 ## Finite set-colimits
 

--- a/src/Cat/Instances/Sets/Complete.lagda.md
+++ b/src/Cat/Instances/Sets/Complete.lagda.md
@@ -26,8 +26,8 @@ indexing category $\cD$ and a diagram $F : \cD \to \Sets$; Let's
 build a limit for it!
 
 ```agda
-Sets-is-complete : ∀ {ι κ o} → is-complete ι κ (Sets (ι ⊔ κ ⊔ o))
-Sets-is-complete {J = D} F = to-limit (to-is-limit lim) module Sets-is-complete where
+Sets-is-complete' : ∀ {ι κ o} → is-complete' ι κ (Sets (ι ⊔ κ ⊔ o))
+Sets-is-complete' {J = D} F = to-make-limit lim module Sets-is-complete where
   module D = Precategory D
   module F = Functor F
   open make-is-limit
@@ -75,6 +75,9 @@ out by $\lim F$ since $K$ is a cone, hence $F(f) \circ \psi(x) =
 
 <!--
 ```agda
+Sets-is-complete : ∀ {ι κ o} → is-complete ι κ (Sets (ι ⊔ κ ⊔ o))
+Sets-is-complete {o = o} = Make-limit→Limit ⊙ Sets-is-complete' {o = o}
+
 module _ {ℓ} where
   open Precategory (Sets ℓ)
 

--- a/src/Data/Set/Coequaliser.lagda.md
+++ b/src/Data/Set/Coequaliser.lagda.md
@@ -259,7 +259,7 @@ projections, we obtain a space where any related objects are identified:
 the **quotient** $A/R$.
 
 ```agda
-private
+module Quot where
   tot : ∀ {ℓ} → (A → A → Type ℓ) → Type (level-of A ⊔ ℓ)
   tot {A = A} R = Σ[ x ∈ A ] Σ[ y ∈ A ] R x y
 
@@ -268,7 +268,10 @@ private
 
   /-right : ∀ {ℓ} {R : A → A → Type ℓ} → tot R → A
   /-right (_ , x , _) = x
+
+open Quot
 ```
+
 <!--
 ```agda
 private variable

--- a/src/Topoi/Classifying/Diaconescu.lagda.md
+++ b/src/Topoi/Classifying/Diaconescu.lagda.md
@@ -127,8 +127,8 @@ module _ {o κ} {C : Precategory o κ} (𝓣 : Topos κ C) where
   private
     module C = Cat.Reasoning C
     abstract
-      colim : is-cocomplete κ κ C
-      colim = Topos-is-cocomplete 𝓣
+      colim : is-cocomplete' κ κ C
+      colim = Colimit→Make-colimit ⊙ Topos-is-cocomplete 𝓣
 ```
 -->
 


### PR DESCRIPTION
# Description

The purpose of this PR is to improve the computational behaviour of (co)limit constructions such as `comma-colimits→lan`.  Currently, (co)limits are defined as Kan extensions, but in most cases they are both produced and consumed using the more direct `make-is-colimit` interface.  The issue with this is that the round-trip `unmake-colimit ∘ to-is-colimit` is not a definitional identity, and can in fact generate significant bloat in the resulting `universal` map.

This PR attempts to remedy this by adding a bundled form of `make-is-colimit` called `Make-colimit` (alternative name suggestions welcome) and similarly for limits, so that code that only wants to consume a colimit using the `make-is-colimit` interface can do so directly, avoiding the roundtrip.  To be clear, the main notion of (co)limit is still `Colimit`, this just provides a way to work directly with `make-is-colimit` when appropriate.

I also added `abstract` annotations on a few equality proofs to further improve the goal terms that one gets when working with (co)limits.

As an example, here is a normalised display form involving the `Realisation` of a functor into `Sets`,
<details>
<summary>
before the PR:
</summary>

```agda
(λ x₁ →
   Coeq-rec (λ { (x , p) → inc (↓obj (x₂ ∘nt ↓Obj.map x) , p) })
   (λ { ((X , x) , (Y , y) , f , q)
          → sym
            (λ i →
               primHComp
               (λ i₁ .o →
                  Prim.Kan.hcomp-sys.sys (i ∨ ~ i)
                  (∙∙-sys.sys
                   (λ i₂ x₃ →
                      inc (↓obj (x₂ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                   (λ i₂ →
                      ((λ i₃ x₃ →
                          inc (↓obj (x₂ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                       ∙∙
                       Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                       underlying
                       (λ c' →
                          Cat.Diagram.Colimit.Base.to-colimit
                          (Cat.Diagram.Colimit.Base.colim
                           (Cat.Instances.Sets.Cocomplete.colim
                            (underlying F∘
                             Dom (Flip (Hom[-,-] C))
                             (Cat.Instances.Shape.Terminal.!Const c')))))
                       x₂ f
                       ∙∙ (λ i₃ x₃ → inc (↓obj (x₂ ∘nt ↓Obj.map X) , x₃)))
                      i₂)
                   (Cr.eliml (Sets κ) (λ i₂ x₃ → x₃)) i)
                  i₁ _ x)
               (primHComp
                (λ i₁ .o →
                   Prim.Kan.hcomp-sys.sys (i ∨ ~ i)
                   (∙∙-sys.sys
                    (λ i₂ x₃ →
                       inc (↓obj (x₂ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                    (Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                     underlying
                     (λ c' →
                        Cat.Diagram.Colimit.Base.to-colimit
                        (Cat.Diagram.Colimit.Base.colim
                         (Cat.Instances.Sets.Cocomplete.colim
                          (underlying F∘
                           Dom (Flip (Hom[-,-] C))
                           (Cat.Instances.Shape.Terminal.!Const c')))))
                     x₂ f)
                    (λ i₂ x₃ → inc (↓obj (x₂ ∘nt ↓Obj.map X) , x₃)) i)
                   i₁ _ x)
                (Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                 underlying
                 (λ c' →
                    Cat.Diagram.Colimit.Base.to-colimit
                    (Cat.Diagram.Colimit.Base.colim
                     (Cat.Instances.Sets.Cocomplete.colim
                      (underlying F∘
                       Dom (Flip (Hom[-,-] C))
                       (Cat.Instances.Shape.Terminal.!Const c')))))
                 x₂ f i x)))
            ∙ ap (λ p₁ → inc (↓obj (x₂ ∘nt ↓Obj.map Y) , p₁)) q
      })
   x₁)
≡
(λ x₁ →
   Coeq-rec (λ { (x , p) → inc (↓obj (y ∘nt ↓Obj.map x) , p) })
   (λ { ((X , x) , (Y , y) , f , q)
          → sym
            (λ i →
               primHComp
               (λ i₁ .o →
                  Prim.Kan.hcomp-sys.sys (i ∨ ~ i)
                  (∙∙-sys.sys
                   (λ i₂ x₃ →
                      inc (↓obj (y₁ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                   (λ i₂ →
                      ((λ i₃ x₃ →
                          inc (↓obj (y₁ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                       ∙∙
                       Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                       underlying
                       (λ c' →
                          Cat.Diagram.Colimit.Base.to-colimit
                          (Cat.Diagram.Colimit.Base.colim
                           (Cat.Instances.Sets.Cocomplete.colim
                            (underlying F∘
                             Dom (Flip (Hom[-,-] C))
                             (Cat.Instances.Shape.Terminal.!Const c')))))
                       y₁ f
                       ∙∙ (λ i₃ x₃ → inc (↓obj (y₁ ∘nt ↓Obj.map X) , x₃)))
                      i₂)
                   (Cr.eliml (Sets κ) (λ i₂ x₃ → x₃)) i)
                  i₁ _ x)
               (primHComp
                (λ i₁ .o →
                   Prim.Kan.hcomp-sys.sys (i ∨ ~ i)
                   (∙∙-sys.sys
                    (λ i₂ x₃ →
                       inc (↓obj (y₁ ∘nt ↓Obj.map Y) , F₁ underlying (↓Hom.top f) x₃))
                    (Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                     underlying
                     (λ c' →
                        Cat.Diagram.Colimit.Base.to-colimit
                        (Cat.Diagram.Colimit.Base.colim
                         (Cat.Instances.Sets.Cocomplete.colim
                          (underlying F∘
                           Dom (Flip (Hom[-,-] C))
                           (Cat.Instances.Shape.Terminal.!Const c')))))
                     y₁ f)
                    (λ i₂ x₃ → inc (↓obj (y₁ ∘nt ↓Obj.map X) , x₃)) i)
                   i₁ _ x)
                (Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
                 underlying
                 (λ c' →
                    Cat.Diagram.Colimit.Base.to-colimit
                    (Cat.Diagram.Colimit.Base.colim
                     (Cat.Instances.Sets.Cocomplete.colim
                      (underlying F∘
                       Dom (Flip (Hom[-,-] C))
                       (Cat.Instances.Shape.Terminal.!Const c')))))
                 y₁ f i x)))
            ∙ ap (λ p₁ → inc (↓obj (y₁ ∘nt ↓Obj.map Y) , p₁)) q
      })
   x₁)
```

</details>

<details>
<summary>
and after:
</summary>

```agda
(λ x₁ →
   Coeq-rec (uncurry (λ j p₁ → inc (↓obj (x ∘nt ↓Obj.map j) , p₁)))
   (Cat.Instances.Sets.Cocomplete.resp
    (underlying F∘
     Dom (Flip (Hom[-,-] C)) (Cat.Instances.Shape.Terminal.!Const A))
    (λ j p₁ → inc (↓obj (x ∘nt ↓Obj.map j) , p₁))
    (λ f x₂ i →
       Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
       underlying
       (λ c' →
          Cat.Diagram.Colimit.Base.to-make-colimit
          (Cat.Instances.Sets.Cocomplete.colim
           (underlying F∘
            Dom (Flip (Hom[-,-] C)) (Cat.Instances.Shape.Terminal.!Const c'))))
       x f i x₂))
   x₁)
≡
(λ x₁ →
   Coeq-rec (uncurry (λ j p₁ → inc (↓obj (y ∘nt ↓Obj.map j) , p₁)))
   (Cat.Instances.Sets.Cocomplete.resp
    (underlying F∘
     Dom (Flip (Hom[-,-] C)) (Cat.Instances.Shape.Terminal.!Const A))
    (λ j p₁ → inc (↓obj (y ∘nt ↓Obj.map j) , p₁))
    (λ f x₂ i →
       Cat.Functor.Kan.Pointwise.comma-colimits→lan.p (Flip (Hom[-,-] C))
       underlying
       (λ c' →
          Cat.Diagram.Colimit.Base.to-make-colimit
          (Cat.Instances.Sets.Cocomplete.colim
           (underlying F∘
            Dom (Flip (Hom[-,-] C)) (Cat.Instances.Shape.Terminal.!Const c'))))
       y f i x₂))
   x₁)
```

</details>

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
