### PR TITLE
defn: Yoneda lemma as a natural isomorphism

### DIFF
--- a/src/Cat/Functor/Hom/Yoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Yoneda.lagda.md
@@ -1,13 +1,16 @@
 <!--
 ```agda
+open import Cat.Functor.Naturality
+open import Cat.Functor.Bifunctor
+open import Cat.Instances.Sets
 open import Cat.Functor.Base
 open import Cat.Functor.Hom
 open import Cat.Prelude
 
 import Cat.Functor.Reasoning.Presheaf as PSh
 
+open _=>_ hiding (op)
 open Functor
-open _=>_
 ```
 -->
 
@@ -131,3 +134,20 @@ as natural transformations $\cC(-,U) \To B$, for any $x : A(U)$.
     y          ∎
 ```
 -->
+
+Finally, we can package the lemma into the statement that there is a
+natural isomorphism between [[bifunctors]] $\cC\op \times [\cC\op,
+\Sets] \to \Sets$, where on the one hand we have the bifunctor which
+acts on an object $c \in \cC$ and a presheaf $A : \cC\op \to \Sets$ by
+evaluating $A$ at $c$, and on the other hand, the bifunctor which
+computes the set of natural transformations from $\yo(c)$ to $A$.
+
+```agda
+module _ {κ} {C : Precategory κ κ} where
+  open Precategory C
+  yoneda-lemma : Flip Id ≅ⁿ よcov (PSh κ C) F∘ op (よ C)
+  yoneda-lemma = biiso→isoⁿ
+    (λ _ A → equiv→iso (yo A , yo-is-equiv A))
+    (λ _ → funext λ _ → yo-naturalr)
+    (λ _ → funext λ _ → yo-naturall)
+```

--- a/src/Cat/Functor/Hom/Yoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Yoneda.lagda.md
@@ -138,9 +138,10 @@ as natural transformations $\cC(-,U) \To B$, for any $x : A(U)$.
 Finally, we can package the lemma into the statement that there is a
 natural isomorphism between [[bifunctors]] $\cC\op \times [\cC\op,
 \Sets] \to \Sets$, where on the one hand we have the bifunctor which
-acts on an object $c \in \cC$ and a presheaf $A : \cC\op \to \Sets$ by
-evaluating $A$ at $c$, and on the other hand, the bifunctor which
-computes the set of natural transformations from $\yo(c)$ to $A$.
+acts on an object $U : \cC$ and a presheaf $A : \cC\op \to \Sets$ by
+evaluating $A$ at $U$, and on the other hand, the bifunctor which
+computes the set of natural transformations from $\cC(-,U)$
+to $A$.
 
 <!--
 ```agda

--- a/src/Cat/Functor/Hom/Yoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Yoneda.lagda.md
@@ -142,11 +142,16 @@ acts on an object $c \in \cC$ and a presheaf $A : \cC\op \to \Sets$ by
 evaluating $A$ at $c$, and on the other hand, the bifunctor which
 computes the set of natural transformations from $\yo(c)$ to $A$.
 
+<!--
 ```agda
 module _ {κ} {C : Precategory κ κ} where
   open Precategory C
-  yoneda-lemma : Flip Id ≅ⁿ よcov (PSh κ C) F∘ op (よ C)
-  yoneda-lemma = biiso→isoⁿ
+```
+-->
+
+```agda
+  yoneda : Flip Id ≅ⁿ よcov (PSh κ C) F∘ op (よ C)
+  yoneda = biiso→isoⁿ
     (λ _ A → equiv→iso (yo A , yo-is-equiv A))
     (λ _ → funext λ _ → yo-naturalr)
     (λ _ → funext λ _ → yo-naturall)


### PR DESCRIPTION
# Description

Adds a formulation of the Yoneda lemma as a natural isomorphism between the evaluation bifunctor and `Nat(y(-),-)`

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
