### PR TITLE
reflection: add first-visible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -874,13 +874,6 @@ record type. This will simply not work. Instead, you can define an
 [`hlevel-projection`] instance as a stand-in for an instance of
 `H-Level` for *any* neutral which quotes to a `def` headed by its index.
 
-An instance of `hlevel-projection` for some name `func` requires an
-hlevel lemma that takes a single visible argument. The `get-argument`
-function must recover this relevant argument from *the argument list* of
-a neutral application of `func`. The `has-level` field should produce a
-`Term` representing the hlevel *for a recovered argument*. Generally,
-`has-level` will be a constant function returning `lit (nat K)`.
-
 [`hlevel-projection`]: https://1lab.dev/1Lab.Reflection.HLevel.html#hlevel-projection
 
 Generally, `hlevel-projection` instances are used for record fields.

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -96,6 +96,9 @@ record hlevel-projection (proj : Name) : Type where
     -- *value*, but in general it may be any single datum computed from
     -- the argument list which is sufficient for lemma pointed to by
     -- 'has-level' to do its work.
+    --
+    -- In the vast majority of cases, this can be 'first-visible'
+    -- (see below).
 
     get-level : Term → TC Term
     -- ^ Given /the inferred type/ of the "relevant" argument, return a
@@ -181,18 +184,22 @@ hlevel-proj A want goal = withNormalisation false do
 
   unify goal soln
 
-open hlevel-projection
+-- | Extract the first visible argument from an argument list. This
+-- is a reasonable implementation of the 'get-argument' field of
+-- 'hlevel-projection' in most cases (e.g. record field projections).
+first-visible : ∀ {ℓ} {A : Type ℓ} → List (Arg A) → TC A
+first-visible (a v∷ as) = pure a
+first-visible (_ ∷ as) = first-visible as
+first-visible [] = typeError []
 
 instance
-  open hlevel-projection
   hlevel-proj-n-type : hlevel-projection (quote n-Type.∣_∣)
   hlevel-proj-n-type .has-level = quote n-Type.is-tr
   hlevel-proj-n-type .get-level ty = do
     def (quote n-Type) (ell v∷ lv't v∷ []) ← reduce ty
       where _ → typeError $ "Type of thing isn't n-Type, it is " ∷ termErr ty ∷ []
     normalise lv't
-  hlevel-proj-n-type .get-argument (_ ∷ _ ∷ it v∷ []) = pure it
-  hlevel-proj-n-type .get-argument _ = typeError []
+  hlevel-proj-n-type .get-argument = first-visible
 
 instance
   H-Level-projection

--- a/src/1Lab/Resizing.lagda.md
+++ b/src/1Lab/Resizing.lagda.md
@@ -85,8 +85,7 @@ instance
   Ω-hlevel-proj : hlevel-projection (quote Ω.∣_∣)
   Ω-hlevel-proj .has-level = quote Ω.is-tr
   Ω-hlevel-proj .get-level x = pure (quoteTerm (suc zero))
-  Ω-hlevel-proj .get-argument (arg _ t ∷ _) = pure t
-  Ω-hlevel-proj .get-argument _ = typeError []
+  Ω-hlevel-proj .get-argument = first-visible
 ```
 -->
 

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -130,9 +130,7 @@ instance
   hlevel-proj-hom : hlevel-projection (quote Precategory.Hom)
   hlevel-proj-hom .has-level = quote hom-set
   hlevel-proj-hom .get-level _ = pure (quoteTerm (suc (suc zero)))
-  hlevel-proj-hom .get-argument (_ ∷ _ ∷ c v∷ _) = pure c
-  {-# CATCHALL #-}
-  hlevel-proj-hom .get-argument _ = typeError []
+  hlevel-proj-hom .get-argument = first-visible
 ```
 -->
 

--- a/src/Cat/Displayed/Base.lagda.md
+++ b/src/Cat/Displayed/Base.lagda.md
@@ -356,11 +356,7 @@ instance
   Hom[]-hlevel-proj : hlevel-projection (quote Displayed.Hom[_])
   Hom[]-hlevel-proj .has-level   = quote Hom[]-set
   Hom[]-hlevel-proj .get-level _ = pure (lit (nat 2))
-  Hom[]-hlevel-proj .get-argument (_ ∷ _ ∷ _ ∷ _ ∷ _ ∷ arg _ t ∷ _) =
-    pure t
-  {-# CATCHALL #-}
-  Hom[]-hlevel-proj .get-argument _ =
-    typeError []
+  Hom[]-hlevel-proj .get-argument = first-visible
 
   Funlike-Displayed : ∀ {o ℓ o' ℓ'} {B : Precategory o ℓ} → Funlike (Displayed B o' ℓ') ⌞ B ⌟ λ _ → Type o'
   Funlike-Displayed = record { _·_ = Displayed.Ob[_] }

--- a/src/Cat/Instances/Assemblies.lagda.md
+++ b/src/Cat/Instances/Assemblies.lagda.md
@@ -142,10 +142,7 @@ instance
   hlevel-proj-asm : hlevel-projection (quote Assembly.Ob)
   hlevel-proj-asm .hlevel-projection.has-level = quote Assembly.has-is-set
   hlevel-proj-asm .hlevel-projection.get-level _ = pure (quoteTerm (suc (suc zero)))
-  hlevel-proj-asm .hlevel-projection.get-argument (_ ∷ _ ∷ _ ∷ c v∷ []) = pure c
-  hlevel-proj-asm .hlevel-projection.get-argument (_ ∷ c v∷ []) = pure c
-  {-# CATCHALL #-}
-  hlevel-proj-asm .hlevel-projection.get-argument _ = typeError []
+  hlevel-proj-asm .hlevel-projection.get-argument = first-visible
 
 module _ (X : Assembly 𝔸 ℓ) (a : ↯ ⌞ 𝔸 ⌟) (x : ⌞ X ⌟) where
   open Ω (X .realisers x .mem a) renaming (∣_∣ to [_]_⊩_) public

--- a/src/Cat/Instances/Graphs.lagda.md
+++ b/src/Cat/Instances/Graphs.lagda.md
@@ -64,16 +64,12 @@ instance
   hlevel-proj-node : hlevel-projection (quote Graph.Node)
   hlevel-proj-node .has-level = quote Graph.Node-set
   hlevel-proj-node .get-level _ = pure (quoteTerm (suc (suc zero)))
-  hlevel-proj-node .get-argument (_ ∷ _ ∷ c v∷ _) = pure c
-  {-# CATCHALL #-}
-  hlevel-proj-node .get-argument _ = typeError []
+  hlevel-proj-node .get-argument = first-visible
 
   hlevel-proj-edge : hlevel-projection (quote Graph.Edge)
   hlevel-proj-edge .has-level = quote Graph.Edge-set
   hlevel-proj-edge .get-level _ = pure (quoteTerm (suc (suc zero)))
-  hlevel-proj-edge .get-argument (_ ∷ _ ∷ c v∷ _) = pure c
-  {-# CATCHALL #-}
-  hlevel-proj-edge .get-argument _ = typeError []
+  hlevel-proj-edge .get-argument = first-visible
 ```
 -->
 

--- a/src/Cat/Instances/OFE.lagda.md
+++ b/src/Cat/Instances/OFE.lagda.md
@@ -125,8 +125,7 @@ instance
   hlevel-proj-ofe : hlevel-projection (quote OFE-on.within)
   hlevel-proj-ofe .has-level       = quote hlevel-within
   hlevel-proj-ofe .get-level _     = pure (quoteTerm (suc zero))
-  hlevel-proj-ofe .get-argument (_ ∷ _ ∷ _ ∷ o v∷ _) = pure o
-  hlevel-proj-ofe .get-argument _ = typeError []
+  hlevel-proj-ofe .get-argument = first-visible
 
 module
   _ {ℓ ℓ₁ ℓ' ℓ₁'} {X : Type ℓ} {Y : Type ℓ₁} (f : X → Y)

--- a/src/Cat/Morphism/Class.lagda.md
+++ b/src/Cat/Morphism/Class.lagda.md
@@ -62,9 +62,7 @@ instance
   Arrows-hlevel-proj : hlevel-projection (quote Arrows.arrows)
   Arrows-hlevel-proj .has-level = quote Arrows.is-tr
   Arrows-hlevel-proj .get-level _ = pure (lit (nat 1))
-  Arrows-hlevel-proj .get-argument (_ ∷ _ ∷ _ ∷ _ ∷ arg _ h ∷ _) = pure h
-  {-# CATCHALL #-}
-  Arrows-hlevel-proj .get-argument _ = typeError []
+  Arrows-hlevel-proj .get-argument = first-visible
 
 {-# DISPLAY Arrows.arrows S f = f ∈ S #-}
 

--- a/src/Data/Set/Coequaliser.lagda.md
+++ b/src/Data/Set/Coequaliser.lagda.md
@@ -482,9 +482,7 @@ instance
   hlevel-proj-congr : hlevel-projection (quote Congruence._∼_)
   hlevel-proj-congr .has-level = quote sim-prop
   hlevel-proj-congr .get-level _ = pure (quoteTerm (suc zero))
-  hlevel-proj-congr .get-argument (_ ∷ _ ∷ _ ∷ c v∷ _) = pure c
-  {-# CATCHALL #-}
-  hlevel-proj-congr .get-argument _ = typeError []
+  hlevel-proj-congr .get-argument = first-visible
 
 private unquoteDecl eqv = declare-record-iso eqv (quote Congruence)
 module _ {R R' : Congruence A ℓ} (p : ∀ x y → Congruence._∼_ R x y ≃ Congruence._∼_ R' x y) where

--- a/src/Data/Set/Material.lagda.md
+++ b/src/Data/Set/Material.lagda.md
@@ -132,8 +132,7 @@ instance
   hlevel-proj-is-iterative-embedding : hlevel-projection (quote is-iterative-embedding)
   hlevel-proj-is-iterative-embedding .has-level   = quote is-iterative-embedding-is-prop
   hlevel-proj-is-iterative-embedding .get-level _ = pure (lit (nat 1))
-  hlevel-proj-is-iterative-embedding .get-argument (_ h∷ x v∷ []) = pure x
-  hlevel-proj-is-iterative-embedding .get-argument _              = typeError []
+  hlevel-proj-is-iterative-embedding .get-argument = first-visible
 
 is-iterative-embedding-is-prop (sup x f) = hlevel 1
 ```
@@ -374,11 +373,7 @@ instance
   hlevel-projection-v-label : hlevel-projection (quote v-label.impl)
   hlevel-projection-v-label .has-level    = quote El-is-set
   hlevel-projection-v-label .get-level _  = pure (lit (nat 2))
-  hlevel-projection-v-label .get-argument a with a
-  ... | v-label-args x = pure x
-  ... | _              = do
-    `a ← quoteTC a >>= normalise
-    typeError [ termErr `a ]
+  hlevel-projection-v-label .get-argument = first-visible
 
 -- We also need the wrapper for this display form, since we can't write
 -- a display form for v-label (S .tree).

--- a/src/Order/Base.lagda.md
+++ b/src/Order/Base.lagda.md
@@ -151,14 +151,12 @@ instance
   Poset-ob-hlevel-proj : hlevel-projection (quote Poset.Ob)
   Poset-ob-hlevel-proj .has-level   = quote Poset.Ob-is-set
   Poset-ob-hlevel-proj .get-level _ = pure (lit (nat 2))
-  Poset-ob-hlevel-proj .get-argument (_ ∷ _ ∷ arg _ t ∷ _) = pure t
-  Poset-ob-hlevel-proj .get-argument _                     = typeError []
+  Poset-ob-hlevel-proj .get-argument = first-visible
 
   Poset-≤-hlevel-proj : hlevel-projection (quote Poset._≤_)
   Poset-≤-hlevel-proj .has-level   = quote Poset.≤-thin
   Poset-≤-hlevel-proj .get-level _ = pure (lit (nat 1))
-  Poset-≤-hlevel-proj .get-argument (_ ∷ _ ∷ arg _ t ∷ _) = pure t
-  Poset-≤-hlevel-proj .get-argument _                     = typeError []
+  Poset-≤-hlevel-proj .get-argument = first-visible
 ```
 -->
 


### PR DESCRIPTION
Adds a convenient way to define `hlevel-projection.get-argument` in the vast majority of cases.