### PR TITLE
Dependent sums create connected limits

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -823,6 +823,10 @@ subst P p x = transport (ap P p) x
 
 <!--
 ```agda
+substd : ∀ {ℓ₁ ℓ₂} {A : I → Type ℓ₁} (P : ∀ {i} → A i → Type ℓ₂) {x : A i0} {y : A i1}
+       → PathP (λ i → A i) x y → P x → P y
+substd P p x = transport (λ i → P (p i)) x
+
 subst₂ : ∀ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : A → Type ℓ₂} (P : (x : A) → B x → Type ℓ₃) {a a' : A} {b : B a} {b' : B a'}
        → (p : a ≡ a') (q : PathP (λ i → B (p i)) b b') → P a b → P a' b'
 subst₂ P p q x = transp (λ i → P (p i) (q i)) i0 x
@@ -1588,7 +1592,7 @@ path (in the middle) with two non-dependent paths on the sides.
 ```agda
 _◁◁_▷▷_
   : ∀ {ℓ} {A : I → Type ℓ} {a₀ a₀' : A i0} {a₁ a₁' : A i1}
-  → a₀ ≡ a₀' → PathP A a₀' a₁ → a₁ ≡ a₁' → PathP A a₀ a₁'
+  → a₀' ≡ a₀ → PathP A a₀ a₁ → a₁ ≡ a₁' → PathP A a₀' a₁'
 (p ◁◁ q ▷▷ r) i = hcomp (∂ i) sys module _◁◁_▷▷_ where
   sys : ∀ j → Partial (∂ i ∨ ~ j) _
   sys j (i = i0) = p (~ j)
@@ -1596,7 +1600,7 @@ _◁◁_▷▷_
   sys j (j = i0) = q i
 
 _◁_ : ∀ {ℓ} {A : I → Type ℓ} {a₀ a₀' : A i0} {a₁ : A i1}
-    → a₀ ≡ a₀' → PathP A a₀' a₁ → PathP A a₀ a₁
+    → a₀' ≡ a₀ → PathP A a₀ a₁ → PathP A a₀' a₁
 p ◁ q = p ◁◁ q ▷▷ refl
 
 _▷_ : ∀ {ℓ} {A : I → Type ℓ} {a₀ : A i0} {a₁ a₁' : A i1}

--- a/src/Algebra/Group/Ab/Free.lagda.md
+++ b/src/Algebra/Group/Ab/Free.lagda.md
@@ -42,9 +42,9 @@ mutual
 ```agda
   Free-abelian⊣Forget
     : ∀ {ℓ} → Free-abelian-functor {ℓ} ⊣ Ab↪Sets
-  Free-abelian⊣Forget = LF⊣GR
-    (free-objects→left-adjoint make-free-group)
-    (free-objects→left-adjoint make-free-abelian)
+  Free-abelian⊣Forget =
+    free-objects→left-adjoint make-free-group
+    ∘⊣ free-objects→left-adjoint make-free-abelian
 ```
 
 <!--

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -663,12 +663,12 @@ _ = Γ⊣Codisc
 
 <!--
 ```agda
-_ = LF⊣GR
+_ = _∘⊣_
 _ = right-adjoint-is-continuous
 ```
 -->
 
-* Proposition 3.2.1: `LF⊣GR`{.Agda}
+* Proposition 3.2.1: `_∘⊣_`{.Agda}
 * Proposition 3.2.2: `right-adjoint-is-continuous`{.Agda}
 
 ### 3.3 The adjoint functor theorem

--- a/src/Cat/CartesianClosed/Locally.lagda.md
+++ b/src/Cat/CartesianClosed/Locally.lagda.md
@@ -210,7 +210,7 @@ each slice of $\cC$ is Cartesian closed.
     slice-cc A = product-adjoint→cartesian-closed (Slice C A) _
       (λ f → Πf (f .map) F∘ Base-change pullbacks (f .map))
       λ A → adjoint-natural-isol (to-natural-iso Slice-product-functor)
-              (LF⊣GR (adj _) (Σf⊣f* _ _))
+              (adj _ ∘⊣ Σf⊣f* _ _)
 ```
 
 <!--
@@ -266,7 +266,7 @@ equivalence $(\cC/B)/f \cong \cC/A$.
   lcc→pullback⊣dependent-product
     : ∀ {a b} (f : Hom a b) → Base-change pullbacks f ⊣ lcc→dependent-product f
   lcc→pullback⊣dependent-product {b = b} f = adjoint-natural-isol
-    (to-natural-iso rem₂) (LF⊣GR rem₁ (Twice⊣Slice f))
+    (to-natural-iso rem₂) (rem₁ ∘⊣ Twice⊣Slice f)
     where
     rem₁ : constant-family prod/ ⊣ exponentiable→product (Slice C _) _ _ _ _
     rem₁ = exponentiable→constant-family⊣product _ _ _ _ _

--- a/src/Cat/Connected.lagda.md
+++ b/src/Cat/Connected.lagda.md
@@ -65,7 +65,7 @@ points *would* be connected by a zigzag, there are no such points.]
 ⊤Cat-is-connected .zigzag _ _ = inc []
 
 module _ {o ℓ} {C : Precategory o ℓ} where
-  open Precategory C
+  private module C = Precategory C
 
   initial→connected : Initial C → is-connected-cat C
   initial→connected init = conn where
@@ -133,4 +133,22 @@ a zigzag.
   connected≃π₀-is-contr : is-connected-cat C ≃ is-contr (π₀ ʻ C)
   connected≃π₀-is-contr = prop-ext (hlevel 1) (hlevel 1)
     connected→π₀-is-contr π₀-is-contr→connected
+```
+
+Connected categories enjoy the following recursion principle: to define
+a map $\| \cC \| \to X$, where $\cC$ is a connected category and $X$ is
+a [[set]], it suffices to give a map $r : | \cC | \to X$ from the
+objects of $\cC$ that gives the same result for any two objects
+connected by a morphism.
+
+```agda
+  connected-∥-∥-rec!
+    : is-connected-cat C
+    → ∀ {ℓ'} {X : Type ℓ'} ⦃ _ : H-Level X 2 ⦄
+    → (r : C.Ob → X)
+    → (∀ {x y} (f : C.Hom x y) → r x ≡ r y)
+    → ∥ C.Ob ∥ → X
+  connected-∥-∥-rec! conn r r-const = ∥-∥-rec-set! r λ x y →
+    case conn .zigzag x y of
+      Meander-rec-≡ (el! _) r r-const
 ```

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -154,16 +154,6 @@ module _ {oj ℓj oc ℓc} {J : Precategory oj ℓj} {C : Precategory oc ℓc} w
   is-colimit▹ F = is-colimit (F F∘ ▹-in) (F .F₀ (inr _)) (cocone▹→cocone F)
 ```
 
-Yet another way of describing a cocone with coapex $X$ is as a functor
-$\cJ \to \cC/X$ into the [[slice category]] over $X$:
-
-```agda
-  cocone/→cocone▹
-    : ∀ {X} → Functor J (Slice C X) → Functor (J ▹) C
-  cocone▹→cocone/
-    : (F : Functor (J ▹) C) → Functor J (Slice C (F .F₀ (inr _)))
-```
-
 <details>
 <summary>The proofs are by simple data repackaging.</summary>
 
@@ -183,26 +173,12 @@ $\cJ \to \cC/X$ into the [[slice category]] over $X$:
 
   cocone▹→cocone F .η j = F .F₁ _
   cocone▹→cocone F .is-natural x y f = sym (F .F-∘ _ _) ∙ sym (idl _)
-
-  cocone/→cocone▹ F .F₀ (inl x) = F .F₀ x .dom
-  cocone/→cocone▹ {X} F .F₀ (inr _) = X
-  cocone/→cocone▹ F .F₁ {inl x} {inl y} (lift f) = F .F₁ f .map
-  cocone/→cocone▹ F .F₁ {inl x} {inr _} f = F .F₀ x .map
-  cocone/→cocone▹ F .F₁ {inr _} {inr _} f = id
-  cocone/→cocone▹ F .F-id {inl x} = ap map (F .F-id)
-  cocone/→cocone▹ F .F-id {inr _} = refl
-  cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inl z} f g = ap map (F .F-∘ _ _)
-  cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inr z} f (lift g) = sym (F .F₁ g .com)
-  cocone/→cocone▹ F .F-∘ {inl x} {inr y} {inr z} f g = sym (idl _)
-  cocone/→cocone▹ F .F-∘ {inr x} {inr y} {inr z} f g = sym (idl _)
-
-  cocone▹→cocone/ F .F₀ j = cut {dom = F .F₀ (inl j)} (F .F₁ _)
-  cocone▹→cocone/ F .F₁ f .map = F .F₁ (lift f)
-  cocone▹→cocone/ F .F₁ f .com = sym (F .F-∘ _ _)
-  cocone▹→cocone/ F .F-id = ext (F .F-id)
-  cocone▹→cocone/ F .F-∘ f g = ext (F .F-∘ _ _)
 ```
 </details>
+
+By the universal property of the join of categories, yet another way
+of describing a cocone with coapex $X$ is as a functor $\cJ \to \cC/X$
+into the [[slice category]] over $X$.
 
 Using this language, we can define what it means for $\cC$
 to have universal colimits in the sense of the first diagram above:
@@ -278,7 +254,7 @@ module _ {oj ℓj oc ℓc}
 ```agda
     step2 =
       ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
-      → is-colimit▹ (cocone▹→cocone/ G) → is-colimit▹ (cocone▹→cocone/ F)
+      → is-colimit▹ (from-▹→to-slice G) → is-colimit▹ (from-▹→to-slice F)
 ```
 
 In the forwards direction, we use the uniqueness of pullbacks to
@@ -291,8 +267,8 @@ colimits, we get that $F$ is colimiting.
     step1→2 u F G α eq G-colim = F-colim where
       f = α .η (inr _)
 
-      f*G≅F : Base-change pb f F∘ cocone▹→cocone/ G F∘ ▹-in
-            ≅ⁿ cocone▹→cocone/ F F∘ ▹-in
+      f*G≅F : Base-change pb f F∘ from-▹→to-slice G F∘ ▹-in
+            ≅ⁿ from-▹→to-slice F F∘ ▹-in
       f*G≅F = iso→isoⁿ
         (λ j → C/.invertible→iso
           (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
@@ -309,7 +285,7 @@ colimits, we get that $F$ is colimiting.
       f*G-colim : preserves-is-lan (Base-change pb f) G-colim
       f*G-colim = u f _ G-colim
 
-      F-colim : is-colimit▹ (cocone▹→cocone/ F)
+      F-colim : is-colimit▹ (from-▹→to-slice F)
       F-colim = natural-isos→is-lan idni
         f*G≅F
         (!const-isoⁿ (C/.invertible→iso
@@ -336,8 +312,8 @@ repackaging data between "obviously isomorphic" functors.
     step2→1 : step2 → has-stable-colimits J C pb
     step2→1 u f F {K} {eta} = trivial-is-colimit! ⊙ u _ _ α eq ⊙ trivial-is-colimit!
       where
-        α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
-         => cocone/→cocone▹ (cocone→cocone▹ eta)
+        α : to-slice→from-▹ (Base-change pb f F∘ cocone→cocone▹ eta)
+         => to-slice→from-▹ (cocone→cocone▹ eta)
         α .η (inl j) = pb _ _ .Pullback.p₁
         α .η (inr _) = f
         α .is-natural (inl x) (inl y) g = pb _ _ .Pullback.p₁∘universal
@@ -375,7 +351,7 @@ $\cC/X \to \cC$ both preserves and reflects colimits.
     module _ (J-colims : ∀ (F : Functor J C) → Colimit F) where
       colim/≃colim
         : (F : Functor (J ▹ ▹) C)
-        → is-colimit▹ (cocone▹→cocone/ F) ≃ is-colimit▹ (F F∘ ▹-in)
+        → is-colimit▹ (from-▹→to-slice F) ≃ is-colimit▹ (F F∘ ▹-in)
       colim/≃colim F =
         prop-ext!
           (lifts→preserves-colimit (Forget/-lifts-colimits (J-colims _)))

--- a/src/Cat/Functor/Adjoint/Compose.lagda.md
+++ b/src/Cat/Functor/Adjoint/Compose.lagda.md
@@ -59,31 +59,33 @@ module _
 -->
 
 ```agda
-  LF⊣GR : (L F∘ F) ⊣ (G F∘ R)
-  LF⊣GR .unit .η x          = G.₁ (lr.η _) A.∘ fg.η _
-  LF⊣GR .counit .η x        = lr.ε _ C.∘ L.₁ (fg.ε _)
+  infixr 30 _∘⊣_
 
-  LF⊣GR .unit .is-natural x y f =
+  _∘⊣_ : (L F∘ F) ⊣ (G F∘ R)
+  _∘⊣_ .unit .η x          = G.₁ (lr.η _) A.∘ fg.η _
+  _∘⊣_ .counit .η x        = lr.ε _ C.∘ L.₁ (fg.ε _)
+
+  _∘⊣_ .unit .is-natural x y f =
     (G.₁ (lr.η _) A.∘ fg.η _) A.∘ f                ≡⟨ A.pullr (fg.unit.is-natural _ _ _) ⟩
     G.₁ (lr.η _) A.∘ G.₁ (F.₁ f) A.∘ fg.η _        ≡⟨ A.pulll (sym (G.F-∘ _ _)) ⟩
     G.₁ ⌜ lr.η _ B.∘ F.₁ f ⌝ A.∘ fg.η _            ≡⟨ ap! (lr.unit.is-natural _ _ _) ⟩
     G.₁ (R.₁ (L.₁ (F.₁ f)) B.∘ lr.η _) A.∘ fg.η _  ≡⟨ A.pushl (G.F-∘ _ _) ⟩
     GR.₁ (LF.₁ f) A.∘ G.₁ (lr.η _) A.∘ (fg.η _)    ∎
 
-  LF⊣GR .counit .is-natural x y f =
+  _∘⊣_ .counit .is-natural x y f =
     (lr.ε _ C.∘ L.₁ (fg.ε _)) C.∘ LF.₁ (GR.₁ f) ≡⟨ C.pullr (sym (L.F-∘ _ _)) ⟩
     lr.ε _ C.∘ L.₁ ⌜ fg.ε _ B.∘ F.₁ (GR.₁ f) ⌝  ≡⟨ ap! (fg.counit.is-natural _ _ _) ⟩
     lr.ε _ C.∘ ⌜ L.₁ (R.F₁ f B.∘ fg.ε _) ⌝      ≡⟨ ap! (L.F-∘ _ _) ⟩
     lr.ε _ C.∘ L.₁ (R.F₁ f) C.∘ L.₁ (fg.ε _)    ≡⟨ C.extendl (lr.counit.is-natural _ _ _) ⟩
     f C.∘ lr.ε _ C.∘ L.₁ (fg.ε _)               ∎
 
-  LF⊣GR .zig =
+  _∘⊣_ .zig =
     (lr.ε _ C.∘ L.₁ (fg.ε _)) C.∘ ⌜ LF.₁ (G.₁ (lr.η _) A.∘ fg.η _) ⌝ ≡⟨ C.extendr (ap! (LF.F-∘ _ _) ∙ L.extendl (fg.counit.is-natural _ _ _)) ⟩
     (lr.ε _ C.∘ L.₁ (lr.η _)) C.∘ (L.₁ (fg.ε _) C.∘ LF.₁ (fg.η _))   ≡⟨ C.elimr (L.annihilate fg.zig) ⟩
     lr.ε _ C.∘ L.₁ (lr.η _)                                          ≡⟨ lr.zig ⟩
     C.id                                                             ∎
 
-  LF⊣GR .zag =
+  _∘⊣_ .zag =
     GR.₁ (lr.ε _ C.∘ L.₁ (fg.ε _)) A.∘ G.₁ (lr.η _) A.∘ fg.η _ ≡⟨ A.pulll (G.collapse (B.pushl (R.F-∘ _ _) ∙ ap₂ B._∘_ refl (sym (lr.unit.is-natural _ _ _)))) ⟩
     G.₁ ⌜ R.₁ (lr.ε _) B.∘ lr.η _ B.∘ fg.ε _ ⌝ A.∘ fg.η _      ≡⟨ ap! (B.cancell lr.zag) ⟩
     G.₁ (fg.ε _) A.∘ fg.η _                                    ≡⟨ fg.zag ⟩

--- a/src/Cat/Functor/Adjoint/Unique.lagda.md
+++ b/src/Cat/Functor/Adjoint/Unique.lagda.md
@@ -174,7 +174,9 @@ As a corollary, we conclude that, for a functor $F : \cC \to \cD$ from a
 proposition.
 
 ```agda
+open adjunction-is-equivalence
 open is-equivalence
+
 is-equivalence-is-prop
   : is-category C
   → (F : Functor C D)
@@ -189,11 +191,11 @@ is-equivalence-is-prop ccat F x y = go where
   go : x ≡ y
   go i .F⁻¹ = invs i
   go i .F⊣F⁻¹ = adjs i
-  go i .unit-iso a =
+  go i .has-is-equivalence .unit-iso a =
     is-prop→pathp (λ i → C.is-invertible-is-prop {f = _⊣_.η (adjs i) a})
       (x .unit-iso a)
       (y .unit-iso a) i
-  go i .counit-iso a =
+  go i .has-is-equivalence .counit-iso a =
     is-prop→pathp (λ i → D.is-invertible-is-prop {f = _⊣_.ε (adjs i) a})
       (x .counit-iso a)
       (y .counit-iso a) i

--- a/src/Cat/Functor/Equivalence.lagda.md
+++ b/src/Cat/Functor/Equivalence.lagda.md
@@ -27,25 +27,19 @@ open _=>_ hiding (op)
 ```
 -->
 
-# Equivalences {defines="equivalence-of-categories equivalences-of-categories"}
+# Equivalences {defines="equivalence-of-categories equivalences-of-categories adjoint-equivalence"}
 
-A functor $F : \cC \to \cD$ is an **equivalence of categories**
-when it has a [[right adjoint]] $G : \cD \to \cD$, with the unit and
-counit natural transformations being [natural isomorphisms]. This
-immediately implies that our adjoint pair $F \dashv G$ extends to an
-adjoint triple $F \dashv G \dashv F$.
-
-[natural isomorphisms]: Cat.Functor.Naturality.html
+An adjunction $F \vdash G$ is an **adjoint equivalence**, or an
+**equivalence of (pre)categories**, if the unit and counit natural
+transformations are both [[natural isomorphisms]]. This immediately
+implies that our adjoint pair $F \dashv G$ extends to an adjoint triple
+$F \dashv G \dashv F$.
 
 ```agda
-record is-equivalence (F : Functor C D) : Type (adj-level C D) where
-  private
-    [C,C] = Cat[ C , C ]
-    [D,D] = Cat[ D , D ]
-
-  field
-    F⁻¹      : Functor D C
-    F⊣F⁻¹    : F ⊣ F⁻¹
+record adjunction-is-equivalence
+    {F : Functor C D} {F⁻¹ : Functor D C}
+    (F⊣F⁻¹ : F ⊣ F⁻¹)
+  : Type (adj-level C D) where
 
   open _⊣_ F⊣F⁻¹ hiding (η ; ε) public
 
@@ -58,6 +52,10 @@ The first thing we note is that having a natural family of invertible
 morphisms gives isomorphisms in the respective functor categories:
 
 ```agda
+  private
+    [C,C] = Cat[ C , C ]
+    [D,D] = Cat[ D , D ]
+
   F∘F⁻¹≅Id : Cat.Isomorphism [D,D] (F F∘ F⁻¹) Id
   F∘F⁻¹≅Id = Cat.invertible→iso [D,D]
     counit
@@ -104,14 +102,34 @@ morphisms gives isomorphisms in the respective functor categories:
       zag' : F .F₁ (unit⁻¹ .η b) D.∘ counit⁻¹ .η (F · b) ≡ D.id
       zag' = ap₂ D._∘_ refl p ∙∙ sym (F .F-∘ _ _) ∙∙ ap (F .F₁) (unit-iso _ .invr) ∙ F .F-id
 
-  inverse-equivalence : is-equivalence F⁻¹
-  inverse-equivalence = record
-    { F⁻¹ = F ; F⊣F⁻¹ = F⁻¹⊣F
-    ; unit-iso   = λ x → Cat.is-invertible-inverse D (counit-iso _)
+  inverse-is-equivalence : adjunction-is-equivalence F⁻¹⊣F
+  inverse-is-equivalence = record
+    { unit-iso   = λ x → Cat.is-invertible-inverse D (counit-iso _)
     ; counit-iso = λ x → Cat.is-invertible-inverse C (unit-iso _)
     }
 ```
 -->
+
+Overloading terminology, a functor $F : \cC \to \cD$ is an **equivalence
+of categories** when it is part of an adjoint equivalence $F \vdash G$.
+
+```agda
+record is-equivalence (F : Functor C D) : Type (adj-level C D) where
+  field
+    F⁻¹   : Functor D C
+    F⊣F⁻¹ : F ⊣ F⁻¹
+
+    has-is-equivalence : adjunction-is-equivalence F⊣F⁻¹
+
+  open adjunction-is-equivalence has-is-equivalence public
+
+  inverse-equivalence : is-equivalence F⁻¹
+  inverse-equivalence = record
+    { F⁻¹ = F
+    ; F⊣F⁻¹ = F⁻¹⊣F
+    ; has-is-equivalence = inverse-is-equivalence
+    }
+```
 
 We chose, for definiteness, the above definition of equivalence of
 categories, since it provides convenient access to the most useful data:
@@ -341,12 +359,13 @@ Now to show they are componentwise invertible:
 -->
 
 ```agda
+  open adjunction-is-equivalence
   open is-equivalence
 
   ff+split-eso→is-equivalence : is-equivalence F
   ff+split-eso→is-equivalence .F⁻¹ = G
   ff+split-eso→is-equivalence .F⊣F⁻¹ = ff+split-eso→F⊣inverse
-  ff+split-eso→is-equivalence .counit-iso x = record
+  ff+split-eso→is-equivalence .has-is-equivalence .counit-iso x = record
     { inv      = f*x-iso .di.from
     ; inverses = record
       { invl = f*x-iso .di.invl
@@ -359,7 +378,7 @@ Since the unit is defined in terms of fullness, showing it is invertible
 needs an appeal to faithfulness (two, actually):
 
 ```agda
-  ff+split-eso→is-equivalence .unit-iso x = record
+  ff+split-eso→is-equivalence .has-is-equivalence .unit-iso x = record
     { inv      = ff⁻¹ (f*x-iso .di.to)
     ; inverses = record
       { invl = ff→faithful {F = F} ff (
@@ -561,6 +580,7 @@ precategories.
 
 <!--
 ```agda
+open adjunction-is-equivalence
 open is-equivalence
 open Precategory
 open _⊣_
@@ -765,12 +785,12 @@ is-equivalence-natural-iso {C = C} {D = D} {F = F} {G = G} α F-eqv = G-eqv wher
   G-eqv : is-equivalence G
   G-eqv .F⁻¹ = F-eqv .F⁻¹
   G-eqv .F⊣F⁻¹ = adjoint-natural-isol α (F-eqv .F⊣F⁻¹)
-  G-eqv .unit-iso x = C.invertible-∘
+  G-eqv .has-is-equivalence .unit-iso x = C.invertible-∘
     (C.invertible-∘
       C.id-invertible
       (F-map-invertible (F-eqv .F⁻¹) (isoⁿ→is-invertible α x)))
     (F-eqv .unit-iso x)
-  G-eqv .counit-iso x = D.invertible-∘ (F-eqv .counit-iso x)
+  G-eqv .has-is-equivalence .counit-iso x = D.invertible-∘ (F-eqv .counit-iso x)
     (D.invertible-∘
       (isoⁿ→is-invertible α _ D.invertible⁻¹)
       (F-map-invertible G C.id-invertible))
@@ -803,11 +823,11 @@ is-equivalence-∘ {E = E} {C = C}  {F = F} {G = G} F-eqv G-eqv = FG-eqv where
   FG-eqv : is-equivalence (F F∘ G)
   FG-eqv .F⁻¹ = G-eqv.F⁻¹ F∘ F-eqv.F⁻¹
   FG-eqv .F⊣F⁻¹ = LF⊣GR G-eqv.F⊣F⁻¹ F-eqv.F⊣F⁻¹
-  FG-eqv .unit-iso x =
+  FG-eqv .has-is-equivalence .unit-iso x =
     C.invertible-∘
       (F-map-invertible G-eqv.F⁻¹ (F-eqv.unit-iso (G .F₀ x)))
       (G-eqv.unit-iso x)
-  FG-eqv .counit-iso x =
+  FG-eqv .has-is-equivalence .counit-iso x =
     E.invertible-∘
       (F-eqv.counit-iso x)
       (F-map-invertible F (G-eqv.counit-iso (F-eqv .F⁻¹ .F₀ x)))
@@ -830,9 +850,9 @@ Id-is-equivalence {C = C} .F⊣F⁻¹ .counit .η x = C .id
 Id-is-equivalence {C = C} .F⊣F⁻¹ .counit .is-natural x y f = C .idl _ ∙ sym (C .idr _)
 Id-is-equivalence {C = C} .F⊣F⁻¹ .zig = C .idl _
 Id-is-equivalence {C = C} .F⊣F⁻¹ .zag = C .idl _
-Id-is-equivalence {C = C} .unit-iso x =
+Id-is-equivalence {C = C} .has-is-equivalence .unit-iso x =
   Cat.make-invertible C (C .id) (C .idl _) (C .idl _)
-Id-is-equivalence {C = C} .counit-iso x =
+Id-is-equivalence {C = C} .has-is-equivalence .counit-iso x =
   Cat.make-invertible C (C .id) (C .idl _) (C .idl _)
 ```
 
@@ -874,12 +894,14 @@ preserves invertibility.
     : preserves-invertibility → is-equivalence L
   preserves-invertibility→equivalence e .F⁻¹ = R
   preserves-invertibility→equivalence e .F⊣F⁻¹ = L⊣R
-  preserves-invertibility→equivalence e .unit-iso c = C.invertible-cancelr
-    (R.F-map-invertible D.id-invertible)
-    (Equiv.to (e D.id _ refl) D.id-invertible)
-  preserves-invertibility→equivalence e .counit-iso d = D.invertible-cancell
-    (L.F-map-invertible C.id-invertible)
-    (Equiv.from (e _ _ (L-R-adjunct L⊣R _)) C.id-invertible)
+  preserves-invertibility→equivalence e .has-is-equivalence .unit-iso c =
+    C.invertible-cancelr
+      (R.F-map-invertible D.id-invertible)
+      (Equiv.to (e D.id _ refl) D.id-invertible)
+  preserves-invertibility→equivalence e .has-is-equivalence .counit-iso d =
+    D.invertible-cancell
+      (L.F-map-invertible C.id-invertible)
+      (Equiv.from (e _ _ (L-R-adjunct L⊣R _)) C.id-invertible)
 ```
 
 The other direction is just as straightforward, since adjuncts are

--- a/src/Cat/Functor/Equivalence.lagda.md
+++ b/src/Cat/Functor/Equivalence.lagda.md
@@ -822,7 +822,7 @@ is-equivalence-∘ {E = E} {C = C}  {F = F} {G = G} F-eqv G-eqv = FG-eqv where
 
   FG-eqv : is-equivalence (F F∘ G)
   FG-eqv .F⁻¹ = G-eqv.F⁻¹ F∘ F-eqv.F⁻¹
-  FG-eqv .F⊣F⁻¹ = LF⊣GR G-eqv.F⊣F⁻¹ F-eqv.F⊣F⁻¹
+  FG-eqv .F⊣F⁻¹ = G-eqv.F⊣F⁻¹ ∘⊣ F-eqv.F⊣F⁻¹
   FG-eqv .has-is-equivalence .unit-iso x =
     C.invertible-∘
       (F-map-invertible G-eqv.F⁻¹ (F-eqv.unit-iso (G .F₀ x)))

--- a/src/Cat/Functor/Equivalence/Path.lagda.md
+++ b/src/Cat/Functor/Equivalence/Path.lagda.md
@@ -3,6 +3,7 @@
 open import Cat.Functor.Adjoint.Unique
 open import Cat.Functor.Equivalence
 open import Cat.Instances.Functor
+open import Cat.Functor.Base
 open import Cat.Prelude
 
 import Cat.Functor.Reasoning as Fr
@@ -36,7 +37,7 @@ Precategory-path
   : ∀ {o ℓ} {C D : Precategory o ℓ} (F : Functor C D)
   → is-precat-iso F
   → C ≡ D
-Precategory-path {o = o} {ℓ} {C} {D} F p = path where
+Precategory-path {o = o} {ℓ} {C} {D} F p = path module Precategory-path where
   module C = Precategory C
   module D = Precategory D
   open is-precat-iso p renaming (has-is-iso to ob≃ ; has-is-ff to hom≃)
@@ -171,6 +172,57 @@ the other laws are not any more enlightening.
              → circ i w y z f (circ i w x y g h) ≡ circ i w x z (circ i x y z f g) h)
         i
         (λ _ _ _ _ f g h → C.assoc f g h) w x y z f g h
+
+Precategory-path→
+  : ∀ {o ℓ o' ℓ'} {C D : Precategory o ℓ} {E : Precategory o' ℓ'}
+  → (F : Functor C D)
+  → (F-iso : is-precat-iso F)
+  → {G : Functor C E} {H : Functor D E}
+  → G ≡ H F∘ F
+  → PathP (λ i → Functor (Precategory-path F F-iso i) E) G H
+Precategory-path→ {E = E} F F-iso {G} {H} com =
+  Functor-pathp ob (λ {x} {y} → hom {x} {y})
+  where
+    module E = Precategory E
+
+    ob-fill : ∀ p → Square _ _ _ _
+    ob-fill p = ∙-filler (ap F₀ com $ₚ p i0) (ap (H .F₀) λ i → unattach (∂ i) (p i))
+
+    ob : ∀ p → G .F₀ (p i0) ≡ H .F₀ (p i1)
+    ob p = ob-fill p i1
+
+    hom : ∀ {x y} r → PathP (λ i → E.Hom (ob x i) (ob y i)) (G .F₁ (r i0)) (H .F₁ (r i1))
+    hom {x} {y} r i = comp (λ j → E.Hom (ob-fill x j i) (ob-fill y j i)) (∂ i) λ where
+      j (i = i0) → G .F₁ (r i0)
+      j (j = i0) → com i .F₁ (r i0)
+      j (i = i1) → H .F₁ (unattach (∂ j) (r j))
+
+→Precategory-path
+  : ∀ {o ℓ o' ℓ'} {C D : Precategory o ℓ} {E : Precategory o' ℓ'}
+  → (F : Functor C D)
+  → (F-iso : is-precat-iso F)
+  → {G : Functor E C} {H : Functor E D}
+  → H ≡ F F∘ G
+  → PathP (λ i → Functor E (Precategory-path F F-iso i)) G H
+→Precategory-path F F-iso {G} {H} com =
+  Functor-pathp ob (λ {x} {y} → hom {x} {y})
+  where
+    module CD i = Precategory (Precategory-path F F-iso i)
+
+    ob-fill : ∀ p → SquareP (λ j i → CD.Ob i) _ _ _ _
+    ob-fill p = ◁◁-▷▷-filler refl
+      (path→ua-pathp _ (sym (ap F₀ com $ₚ p i0)))
+      (ap (H .F₀) (λ i → p i))
+
+    ob : ∀ p → PathP CD.Ob (G .F₀ (p i0)) (H .F₀ (p i1))
+    ob p = ob-fill p i1
+
+    hom : ∀ {x y} r → PathP (λ i → CD.Hom i (ob x i) (ob y i)) (G .F₁ (r i0)) (H .F₁ (r i1))
+    hom {x} {y} r i = comp (λ j → CD.Hom i (ob-fill x j i) (ob-fill y j i)) (∂ i) λ where
+      j (i = i0) → G .F₁ (r i0)
+      j (j = i0) → Precategory-path.hom-glue F F-iso i (ob-fill x i0 i) (ob-fill y i0 i)
+        (λ { (i = i0) → _ }) (inS (com (~ i) .F₁ (r i0)))
+      j (i = i1) → H .F₁ (r j)
 ```
 -->
 

--- a/src/Cat/Functor/Monadic/Crude.lagda.md
+++ b/src/Cat/Functor/Monadic/Crude.lagda.md
@@ -285,11 +285,12 @@ crude-monadicity
     (U-conservative : is-conservative U)
   → is-monadic F⊣U
 crude-monadicity coeq pres cons = eqv' where
+  open adjunction-is-equivalence
   open is-equivalence
   eqv : is-equivalence (Comparison-EM⁻¹ F⊣U coeq)
-  eqv .F⁻¹          = Comparison-EM F⊣U
-  eqv .F⊣F⁻¹        = Comparison-EM⁻¹⊣Comparison-EM F⊣U coeq
-  eqv .unit-iso _   = prcoeq→unit-is-iso coeq pres
-  eqv .counit-iso _ = conservative-prcoeq→counit-is-iso coeq pres cons
+  eqv .F⁻¹                              = Comparison-EM F⊣U
+  eqv .F⊣F⁻¹                            = Comparison-EM⁻¹⊣Comparison-EM F⊣U coeq
+  eqv .has-is-equivalence .unit-iso _   = prcoeq→unit-is-iso coeq pres
+  eqv .has-is-equivalence .counit-iso _ = conservative-prcoeq→counit-is-iso coeq pres cons
   eqv' = inverse-equivalence eqv
 ```

--- a/src/Cat/Functor/Pullback.lagda.md
+++ b/src/Cat/Functor/Pullback.lagda.md
@@ -1,16 +1,25 @@
 <!--
 ```agda
 open import Cat.Functor.Adjoint.Comonadic
+open import Cat.Functor.Equivalence.Path
+open import Cat.Instances.Slice.Colimit
+open import Cat.Instances.Slice.Limit
+open import Cat.Instances.Slice.Twice
+open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Coalgebras
 open import Cat.Functor.Equivalence
+open import Cat.Diagram.Limit.Base
 open import Cat.Functor.Properties
 open import Cat.Diagram.Pullback
 open import Cat.Diagram.Initial
+open import Cat.Diagram.Product
 open import Cat.Displayed.Total
 open import Cat.Functor.Adjoint
 open import Cat.Functor.Compose
 open import Cat.Instances.Comma
 open import Cat.Instances.Slice
+open import Cat.Functor.Base
+open import Cat.Connected
 open import Cat.Univalent
 open import Cat.Prelude
 
@@ -122,13 +131,9 @@ functorial, but the details are not particularly enlightening.</summary>
 
 ## Properties
 
-The base change functor is a right adjoint. We construct the left
-adjoint directly, then give the unit and counit, and finally prove the
-triangle identities.
-
 :::{.definition #dependent-sum}
-The [[left adjoint]], called _dependent sum_ and written $\sum_f : \cC/Y
-\to \cC/X$, is given
+The base change functor is a right adjoint. The [[left adjoint]],
+called _dependent sum_ and written $\Sigma_f : \cC/Y \to \cC/X$, is given
 on objects by precomposition with $f$, and on morphisms by what is
 essentially the identity function --- only the witness of commutativity
 must change.
@@ -141,8 +146,24 @@ module _ {X Y : Ob} (f : Hom Y X) where
   Σf .F₁ dh = record { map = dh .map ; com = pullr (dh .com) }
   Σf .F-id    = ext refl
   Σf .F-∘ f g = ext refl
+```
 
-  open _⊣_
+By the characterisation of [[iterated slices]], we may identify $\cC/Y$
+with $(\cC/B)/f$; under this identification, the base change functor is
+identical to the "constant families" functor $f^* : \cC/B \to (\cC/B)/f$
+(seeing $f$ as an *object* of $\cC/B$ rather than a morphism of $\cC$,
+and remembering that products with $f$ in $\cC/B$ are *pullbacks* along
+$f$ in $\cC$), while the left adjoint $\Sigma_f$ coincides with the
+forgetful functor $(\cC/B)/f \to \cC/B$.
+
+```agda
+Forget/≡Σf
+  : {X Y : Ob} (f : Hom Y X)
+  → PathP (λ i → Functor (Twice≡Slice {C = C} f i) (Slice C X))
+    Forget/ (Σf f)
+Forget/≡Σf f = Precategory-path→ _ _ $ Functor-path
+  (λ o → /-Obj-path refl (sym (o .map .com)))
+  λ f → /-Hom-pathp _ _ refl
 ```
 
 <!--
@@ -176,18 +197,39 @@ module _ {X Y : Ob} (f : Hom Y X) where
 ```
 -->
 
-The adjunction unit and counit are given by the universal properties of
-pullbacks.
-
-<!-- [TODO: Amy, 2022-03-23]
-Explain this better
--->
-
+<!--
 ```agda
+_ = Forget⊣constant-family
+_ = Forget/-comonadic
+
 module _ (pullbacks : ∀ {X Y Z} f g → Pullback C {X} {Y} {Z} f g) {X Y : Ob} (f : Hom Y X) where
   open _⊣_
   open _=>_
 
+  private
+    prod/ : has-products (Slice C X)
+    prod/ = Slice-products pullbacks
+```
+-->
+
+```agda
+  constant-family≡Base-change
+    : PathP (λ i → Functor (Slice C X) (Twice≡Slice {C = C} f i))
+      (constant-family prod/) (Base-change pullbacks f)
+  constant-family≡Base-change = →Precategory-path _ _ $ Functor-path
+    (λ o → /-Obj-path refl refl)
+    λ g → /-Hom-pathp _ _ (ap (Pullback.universal (pullbacks _ _)) prop!)
+```
+
+Thus, many of the results in this section could in principle be
+derived automatically, but we opt to spell them out explicitly for
+formalisation reasons.
+
+The unit and counit of the adjunction $\Sigma_f \dashv f^*$ are given by
+the universal properties of pullbacks; this is an instance of the
+`Forget⊣constant-family`{.Agda} adjunction.
+
+```agda
   Σf⊣f* : Σf f ⊣ Base-change pullbacks f
   Σf⊣f* .unit .η obj = dh where
     module pb = Pullback (pullbacks (f ∘ obj .map) f)
@@ -225,12 +267,15 @@ module _ (pullbacks : ∀ {X Y Z} f g → Pullback C {X} {Y} {Z} f g) {X Y : Ob}
     module pb' = Pullback (pullbacks (f ∘ pb.p₂) f)
 ```
 
-This adjunction is [[comonadic]]; this generalises the [[fact|constant
-family]] that the forgetful functor $\cC/Y \to \cC$ is comonadic,
-which we recover by taking $f : Y \to \top$.
+This adjunction is [[comonadic]]. This generalises the
+`fact`{.Agda ident=Forget/-comonadic} that the
+forgetful functor $\cC/Y \to \cC$ is comonadic, which we recover by
+taking $f : Y \to \top$; by the discussion above, it is also a
+*consequence* of the same fact applied to the forgetful functor
+$(\cC/B)/f \to \cC/B$.
 
 The idea is the same, only with more dependent types: thinking of $Y$ as
-a family of types over $X$, the comonad $\sum_f \circ f^* : \cC/X \to
+a family of types over $X$, the comonad $\Sigma_f \circ f^* : \cC/X \to
 \cC/X$ sends a map $A \to X$ to the projection map $A \times_X Y \to X$.
 Therefore, a coalgebra for this comonad consists of a map $\langle g, h
 \rangle : A \to A \times_X Y$ over $X$; but the coalgebra laws force
@@ -276,6 +321,24 @@ object of $(\cC/X)/f$, or [[in other words|iterated slice]] $\cC/Y$.
           module pby = Pullback (pullbacks (f ∘ y .map) f)
       ff .rinv _ = ext refl
       ff .linv _ = ext refl
+```
+
+By transporting the analogous results for `Forget/`{.Agda}, $\Sigma_f$
+[[creates|created limit]] [[connected|connected category]] limits and
+all colimits.
+
+```agda
+module _ {oj ℓj} {J : Precategory oj ℓj} {X Y} {f : Hom X Y} where
+
+  Σf-creates-connected-limits
+    : is-connected-cat J
+    → creates-limits-of J (Σf f)
+  Σf-creates-connected-limits conn = substd (creates-limits-of J)
+    (Forget/≡Σf f) (Forget/-creates-connected-limits conn)
+
+  Σf-creates-colimits : creates-colimits-of J (Σf f)
+  Σf-creates-colimits = substd (creates-colimits-of J)
+    (Forget/≡Σf f) Forget/-creates-colimits
 ```
 
 ## Equifibred natural transformations {defines="equifibred cartesian-natural-transformation"}

--- a/src/Cat/Instances/Shape/Cospan.lagda.md
+++ b/src/Cat/Instances/Shape/Cospan.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Diagram.Terminal
 open import Cat.Prelude
 open import Cat.Finite
 
@@ -117,6 +118,12 @@ instance
   cs-c cs-a → auto
   cs-c cs-b → auto
   cs-c cs-c → auto
+
+Terminal-·→·←· : ∀ {a b} → Terminal (·→·←· {a} {b})
+Terminal-·→·←· .Terminal.top = cs-c
+Terminal-·→·←· .Terminal.has⊤ cs-a = hlevel 0
+Terminal-·→·←· .Terminal.has⊤ cs-b = hlevel 0
+Terminal-·→·←· .Terminal.has⊤ cs-c = hlevel 0
 ```
 -->
 

--- a/src/Cat/Instances/Shape/Join.lagda.md
+++ b/src/Cat/Instances/Shape/Join.lagda.md
@@ -1,12 +1,15 @@
 <!--
 ```agda
 open import Cat.Instances.Shape.Terminal
+open import Cat.Instances.Slice
 open import Cat.Prelude
 
 open import Data.Sum
 
 open Precategory
 open Functor
+open /-Obj
+open /-Hom
 ```
 -->
 
@@ -14,7 +17,7 @@ open Functor
 module Cat.Instances.Shape.Join where
 ```
 
-# Join of categories
+# Join of categories {defines="join-of-categories"}
 
 The **join** $\cC \star \cD$ of two categories is the category
 obtained by "bridging" the disjoint union $\cC \coprod \cD$ with a
@@ -143,3 +146,42 @@ module _ {o ℓ} {J : Precategory o ℓ} where
   ▹-join .F-∘ {inl (inr x)} {inr y} {inr z} f g = refl
   ▹-join .F-∘ {inr x} {inr y} {inr z} f g = refl
 ```
+
+The join of categories, when viewed as a functor $- \star \cB : \Cat \to
+\cB/\Cat$, has a [[right adjoint]] which takes a pair ($\cD, F : \cB
+\to \cD$) to the [[comma category]] $\cD \downarrow F$. Specialising
+this to $\cB = \top$, this becomes a [[slice category]], thus a functor
+$F : \cC^\triangleright \to \cD$ is the same as a functor $\cC \to
+\cD/F(\ast)$.
+
+```agda
+module _ {o ℓ o' ℓ'} {J : Precategory o ℓ} {C : Precategory o' ℓ'} where
+  from-▹→to-slice
+    : (F : Functor (J ▹) C) → Functor J (Slice C (F .F₀ (inr _)))
+  to-slice→from-▹
+    : ∀ {X} → Functor J (Slice C X) → Functor (J ▹) C
+```
+
+<details>
+<summary>The proof is by data repackaging.</summary>
+
+```agda
+  to-slice→from-▹ F .F₀ (inl x) = F .F₀ x .dom
+  to-slice→from-▹ {X} F .F₀ (inr _) = X
+  to-slice→from-▹ F .F₁ {inl x} {inl y} (lift f) = F .F₁ f .map
+  to-slice→from-▹ F .F₁ {inl x} {inr _} f = F .F₀ x .map
+  to-slice→from-▹ F .F₁ {inr _} {inr _} f = C .id
+  to-slice→from-▹ F .F-id {inl x} = ap map (F .F-id)
+  to-slice→from-▹ F .F-id {inr _} = refl
+  to-slice→from-▹ F .F-∘ {inl x} {inl y} {inl z} f g = ap map (F .F-∘ _ _)
+  to-slice→from-▹ F .F-∘ {inl x} {inl y} {inr z} f (lift g) = sym (F .F₁ g .com)
+  to-slice→from-▹ F .F-∘ {inl x} {inr y} {inr z} f g = sym (C .idl _)
+  to-slice→from-▹ F .F-∘ {inr x} {inr y} {inr z} f g = sym (C .idl _)
+
+  from-▹→to-slice F .F₀ j = cut {dom = F .F₀ (inl j)} (F .F₁ _)
+  from-▹→to-slice F .F₁ f .map = F .F₁ (lift f)
+  from-▹→to-slice F .F₁ f .com = sym (F .F-∘ _ _)
+  from-▹→to-slice F .F-id = ext (F .F-id)
+  from-▹→to-slice F .F-∘ f g = ext (F .F-∘ _ _)
+```
+</details>

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -16,6 +16,7 @@ open import Cat.Diagram.Comonad
 open import Cat.Diagram.Product
 open import Cat.Displayed.Total
 open import Cat.Functor.Adjoint
+open import Cat.Instances.Comma
 open import Cat.Functor.Base
 open import Cat.Cartesian
 open import Cat.Prelude
@@ -863,4 +864,43 @@ $\cC/B$.
         x .map                                      ∎
       ff .rinv _ = ext refl
       ff .linv _ = ext refl
+```
+
+## As comma categories
+
+The slice category $\cC/X$ can also be described as the [[comma
+category]] $\cC \swarrow X$, where $\cC$ stands for the identity functor
+$\cC \to \cC$ and $X$ stands for the constant functor $X : \top \to \cC$.
+
+<!--
+```agda
+module _ {o ℓ} (C : Precategory o ℓ) X where
+  open is-precat-iso
+  open ↓Obj
+  open ↓Hom
+```
+-->
+
+```agda
+  Slice→Comma : Functor (Slice C X) (Id {C = C} ↘ X)
+  Slice→Comma .F₀ o .dom = o .dom
+  Slice→Comma .F₀ o .cod = tt
+  Slice→Comma .F₀ o .map = o .map
+  Slice→Comma .F₁ f .top = f .map
+  Slice→Comma .F₁ f .bot = tt
+  Slice→Comma .F₁ f .com = f .com ∙ sym (C .Precategory.idl _)
+  Slice→Comma .F-id      = ext refl
+  Slice→Comma .F-∘ _ _   = ext refl
+
+  Slice≃Comma : is-precat-iso Slice→Comma
+  Slice≃Comma .has-is-iso = is-iso→is-equiv λ where
+    .is-iso.from o .dom → o .dom
+    .is-iso.from o .map → o .map
+    .is-iso.rinv _ → ext refl
+    .is-iso.linv _ → /-Obj-path refl refl
+  Slice≃Comma .has-is-ff = is-iso→is-equiv λ where
+    .is-iso.from f .map → f .top
+    .is-iso.from f .com → f .com ∙ C .Precategory.idl _
+    .is-iso.rinv _ → ext refl
+    .is-iso.linv _ → ext refl
 ```

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -724,11 +724,11 @@ If $\cC/B$ is the category of _families of $\cC$-objects indexed by
 $B$_, it stands to reason that we should be able to consider _any_
 object $A : \cC$ as a family over $B$, where each fibre of the family is
 isomorphic to $A$. Type-theoretically, this would correspond to taking a
-closed type and trivially regarding it as living in a context $\Gamma$
+closed type and trivially regarding it as living in a context $B$
 by ignoring the context entirely.
 
 From the perspective of slice categories, the **constant families
-functor**, $\Delta : \cC \to \cC/B$, sends an object $A : \cC$ to the
+functor**, $B^* : \cC \to \cC/B$, sends an object $A : \cC$ to the
 projection morphism $\pi_2 : A \times B \to B$.
 
 ```agda
@@ -747,7 +747,7 @@ module _ {o ℓ} {C : Precategory o ℓ} {B} (prod : has-products C) where
 
 We can observe that this really is a _constant families_ functor by
 performing the following little calculation: If we have a map $h : Y \to
-B$, then the fibre of $\Delta_B(A)$ over $h$ is isomorphic to $A \times Y$;
+B$, then the fibre of $B^* A$ over $h$ is isomorphic to $A \times Y$;
 that is, we have the following pullback square:
 
 ~~~{.quiver}
@@ -795,7 +795,8 @@ functor $\cC \to \cC/B$ that is just the constant families functor.
 On the other hand, the "dependent sum" functor sends a map $A \to B$
 to the unique composite $A \to B \to \top$: it simply `Forget/`{.Agda}s the
 map. Thus the following adjunction is a special case of the
-adjunction between [[dependent sum]] and base change.
+adjunction between [[dependent sum]] and base change, and we refer to
+the forgetful functor as $\Sigma_B$.
 
 ```agda
   Forget⊣constant-family : Forget/ ⊣ constant-family
@@ -817,20 +818,20 @@ adjunction between [[dependent sum]] and base change.
 ```
 
 Furthermore, this adjunction is [[comonadic]]! First, notice
-that the [[induced comonad|comonad from an adjunction]] $U \circ \Delta$
+that the [[induced comonad|comonad from an adjunction]] $\Sigma_B \circ B^*$
 on $\cC$ is none other than the [[writer comonad]] $B \times -$, up to
 swapping.
 
 ```agda
-  UΔ≡Writer : Forget/ F∘ constant-family ≅ⁿ Writer C B (prod B)
-  UΔ≡Writer = iso→isoⁿ
+  Forget∘constant≅Writer : Forget/ F∘ constant-family ≅ⁿ Writer C B (prod B)
+  Forget∘constant≅Writer = iso→isoⁿ
     (λ _ → invertible→iso swap swap-is-iso)
     λ f → (ap ⟨_, f ∘ π₂ ⟩ (sym (idl _)) ⟩∘⟨refl)
        ∙∙ swap-natural (f , id)
        ∙∙ (refl⟩∘⟨ ap ⟨ f ∘ π₁ ,_⟩ (idl _))
 ```
 
-It remains to ponder what a $U\Delta$-coalgebra on $A$ is: this should
+It remains to ponder what a $\Sigma_B B^*$-coalgebra on $A$ is: this should
 consist of a map $\langle f, g \rangle : A \to A \times B$ obeying some
 laws. In particular, the `counit law`{.Agda ident=ρ-counit} implies that
 $f = \id$, so that we are left with $g : A \to B$, an object of $\cC/B$!
@@ -848,9 +849,9 @@ $f = \id$, so that we are left with $g : A \to B$, an object of $\cC/B$!
       eso .linv _ = /-Obj-path refl π₂∘⟨⟩
 ```
 
-A short computation shows that morphisms of $U\Delta$-coalgebras also
+A short computation shows that morphisms of $\Sigma_B B^*$-coalgebras also
 precisely correspond to commuting triangles, so we get an [[isomorphism
-of precategories]] between the category of $U\Delta$-coalgebras and
+of precategories]] between the category of $\Sigma_B B^*$-coalgebras and
 $\cC/B$.
 
 ```agda

--- a/src/Cat/Instances/Slice/Limit.lagda.md
+++ b/src/Cat/Instances/Slice/Limit.lagda.md
@@ -1,10 +1,13 @@
 <!--
 ```agda
 open import Cat.Instances.Shape.Terminal
+open import Cat.Instances.Localisation
+open import Cat.Functor.Conservative
 open import Cat.Instances.Shape.Join
 open import Cat.Diagram.Limit.Base
 open import Cat.Diagram.Terminal
 open import Cat.Instances.Slice
+open import Cat.Connected
 open import Cat.Prelude
 
 open import Data.Sum
@@ -69,7 +72,6 @@ module
     (F : Functor J (Slice C o))
     where
 
-  open Terminal
   open /-Obj
   open /-Hom
 
@@ -158,4 +160,102 @@ is-complete→slice-is-complete
   → is-complete o' ℓ' C
   → is-complete o' ℓ' (Slice C c)
 is-complete→slice-is-complete lims F = limit-above→limit-in-slice F (lims _)
+```
+
+## Connected limits in slices {defines="connected-limits-in-slice-categories"}
+
+We can simplify this story for a particular class of limits: the
+forgetful functor $U : \cC/o \to \cC$ [[creates|created limit]]
+*connected* limits.^[That is, limits of shape a [[connected category]].
+This notably includes [[pullbacks]], but *not* terminal objects or
+binary products, since their shape categories have respectively 0 and 2
+connected components.]
+For instance, a [[pullback]] in $\cC/o$ is computed exactly as a
+pullback in $\cC$ (assuming this pullback exists), ignoring the maps
+into $o$. Contrast this with the fact that [[colimits in slice
+categories]] are *all* created by the forgetful functor.
+
+To get some intuition for the connectedness requirement, we can think
+type-theoretically: an object of $\cC/A$ is, in the internal language of
+$\cC$, a "type in context $A$", $a : A \vdash B(a)$, while the forgetful
+functor can be thought of as forming the $\Sigma$-type $\sum_{a : A} B(a)$.
+Then, given a diagram of types $a : A \vdash B_i(a)$ in $\cC/A$ with
+maps between them over $A$, the limit of the induced diagram of closed
+types consists of a bunch of pairs $(a_i : A, b_i : B_i(a_i))$ obeying
+some relations; but, since the diagram has a connected shape, those
+relations ensure that all the $a_i$s are equal! Thus, it is enough
+to compute the limit *over $A$* and then take the $\Sigma$.
+
+<!--
+```agda
+module
+  _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {J : Precategory o' ℓ'} {A : ⌞ C ⌟}
+    where
+
+  private
+    module C = Cat.Reasoning C
+    module J = Precategory J
+
+  open lifts-limit
+  open /-Obj
+  open /-Hom
+```
+-->
+
+We start by showing that `Forget/`{.Agda} [[lifts limits]]: given a
+diagram $D$ in $\cC/A$ and its limit $L$ in $\cC$, the key step is to find
+a suitable map $L \to A$ to promote this to a limit in $\cC/A$.
+As hinted above, we can pick any object $j : J$ and set this to the
+composite $L \to D_j \to A$; since $J$ is connected, the choice of
+$j$ doesn't matter, and there is at least one object by assumption.
+
+```agda
+  Forget/-lifts-connected-limits
+    : is-connected-cat J
+    → lifts-limits-of J (Forget/ {C = C} {c = A})
+  Forget/-lifts-connected-limits conn {D} L .lifted = to-limit (to-is-limit L')
+    where
+      module D = Functor D
+      module L = Limit L
+      module conn = is-connected-cat conn
+
+      proj : J.Ob → C.Hom L.apex A
+      proj j = D.₀ j .map C.∘ L.ψ j
+
+      proj' : ∥ J.Ob ∥ → C.Hom L.apex A
+      proj' = connected-∥-∥-rec! conn proj λ {x} {y} f →
+        D.₀ x .map C.∘ L.ψ x                ≡⟨ C.pushl (sym (D.₁ f .com)) ⟩
+        D.₀ y .map C.∘ D.₁ f .map C.∘ L.ψ x ≡⟨ C.cdr (L.commutes f) ⟩
+        D.₀ y .map C.∘ L.ψ y                ∎
+```
+
+The rest is an uneventful computation.
+
+```agda
+      L' : make-is-limit D (cut (proj' conn.point))
+      L' .make-is-limit.ψ j .map = L.ψ j
+      L' .make-is-limit.ψ j .com = ap proj' (squash (inc _) conn.point)
+      L' .make-is-limit.commutes f = ext (L.commutes f)
+      L' .make-is-limit.universal eps comm .map =
+        L.universal (λ j → eps j .map) λ {x} {y} f → unext (comm f)
+      L' .make-is-limit.universal eps comm .com =
+        case conn.point return (λ p → proj' p C.∘ _ ≡ _) of λ j →
+          C.pullr (L.factors _ _) ∙ eps j .com
+      L' .make-is-limit.factors eps comm = ext (L.factors _ _)
+      L' .make-is-limit.unique eps comm other fac =
+        ext (L.unique _ _ _ λ j → unext (fac j))
+
+  Forget/-lifts-connected-limits conn lim .preserved =
+    generalize-limitp (Limit.has-limit lim) refl
+```
+
+Since `Forget/`{.Agda} is [[conservative]], we conclude that it creates
+connected limits.
+
+```agda
+  Forget/-creates-connected-limits
+    : is-connected-cat J
+    → creates-limits-of J (Forget/ {C = C} {c = A})
+  Forget/-creates-connected-limits conn = conservative+lifts→creates-limits
+    Forget/-is-conservative (Forget/-lifts-connected-limits conn)
 ```

--- a/src/Cat/Instances/Slice/Limit.lagda.md
+++ b/src/Cat/Instances/Slice/Limit.lagda.md
@@ -61,9 +61,8 @@ $\bullet \to \bullet \ot \bullet$. This process can be described in a
 way easier to generalise: We "exploded" our diagram $F : \{*,*\} \to
 \cC/c$ to one indexed by a category which contains $\{*,*\}$,
 contains an extra point, and has a unique map between each object of
-$\{*,*\}$ --- the [_join_] of these categories.
-
-[_join_]: Cat.Instances.Shape.Join.html
+$\{*,*\}$ --- we have [[adjoined|adjoined terminal object]] a
+[[terminal object]] to our diagram shape.
 
 <!--
 ```agda
@@ -84,22 +83,12 @@ module
 -->
 
 Generically, if we have a diagram $F : J \to \cC/c$, we can "explode"
-this into a diagram $F' : (J \star \{*\}) \to \cC$, compute the limit
+this into a diagram $F' : cJ^\triangleright \to \cC$, compute the limit
 in $\cC$, then pass back to the slice category.
 
 ```agda
-    F' : Functor (J ⋆ ⊤Cat) C
-    F' .F₀ (inl x) = F.₀ x .dom
-    F' .F₀ (inr x) = o
-    F' .F₁ {inl x} {inl y} (lift f) = F.₁ f .map
-    F' .F₁ {inl x} {inr y} _ = F.₀ x .map
-    F' .F₁ {inr x} {inr y} (lift h) = C.id
-    F' .F-id {inl x} = ap map F.F-id
-    F' .F-id {inr x} = refl
-    F' .F-∘ {inl x} {inl y} {inl z} (lift f) (lift g) = ap map (F.F-∘ f g)
-    F' .F-∘ {inl x} {inl y} {inr z} (lift f) (lift g) = sym (F.F₁ g .com)
-    F' .F-∘ {inl x} {inr y} {inr z} (lift f) (lift g) = C.introl refl
-    F' .F-∘ {inr x} {inr y} {inr z} (lift f) (lift g) = C.introl refl
+    F' : Functor (J ▹) C
+    F' = to-slice→from-▹ F
 
   limit-above→limit-in-slice : Limit F' → Limit F
   limit-above→limit-in-slice lims = to-limit (to-is-limit lim) where

--- a/src/Cat/Instances/Slice/Twice.lagda.md
+++ b/src/Cat/Instances/Slice/Twice.lagda.md
@@ -1,6 +1,7 @@
 <!--
 ```agda
-open import Cat.Functor.Adjoint
+open import Cat.Functor.Equivalence.Path
+open import Cat.Functor.Equivalence
 open import Cat.Instances.Slice
 open import Cat.Prelude
 
@@ -18,8 +19,6 @@ open Cat.Reasoning C
 open Functor
 open /-Obj
 open /-Hom
-open _=>_
-open _⊣_
 private variable
   a b : Ob
 ```
@@ -47,21 +46,10 @@ information, by explicitly writing out $h = fg$ and setting $p = \refl$.
 Its inverse simply discards the redundant information. We construct both
 of the functors here, in components.
 
+We construct the functor $(\cC/B)/f \to \cC/A$ and show that it is
+an isomorphism.
+
 ```agda
-Slice-twice : (f : Hom a b) → Functor (Slice C a) (Slice (Slice C b) (cut f))
-Slice-twice f .F₀ g .dom .dom = g .dom
-Slice-twice f .F₀ g .dom .map = f ∘ g .map
-
-Slice-twice f .F₀ g .map .map = g .map
-Slice-twice f .F₀ g .map .com = refl
-
-Slice-twice f .F₁ h .map .map = h .map
-Slice-twice f .F₁ h .map .com = pullr (h .com)
-Slice-twice f .F₁ h .com      = ext (h .com)
-
-Slice-twice f .F-id    = ext refl
-Slice-twice f .F-∘ g h = ext refl
-
 Twice-slice : (f : Hom a b) → Functor (Slice (Slice C b) (cut f)) (Slice C a)
 Twice-slice _ .F₀ x .dom = x .dom .dom
 Twice-slice _ .F₀ x .map = x .map .map
@@ -71,24 +59,26 @@ Twice-slice _ .F₁ h .com = ap map (h .com)
 
 Twice-slice _ .F-id    = ext refl
 Twice-slice _ .F-∘ _ _ = ext refl
-```
 
-We will also need the fact that these inverses are also adjoints.
+Twice≃Slice : (f : Hom a b) → is-precat-iso (Twice-slice f)
+Twice≃Slice f .is-precat-iso.has-is-iso = is-iso→is-equiv λ where
+  .is-iso.from o .dom .dom → o .dom
+  .is-iso.from o .dom .map → f ∘ o .map
+  .is-iso.from o .map .map → o .map
+  .is-iso.from o .map .com → refl
+  .is-iso.rinv o           → /-Obj-path refl refl
+  .is-iso.linv o           → /-Obj-path (/-Obj-path refl (o .map .com)) (/-Hom-pathp _ _ refl)
+Twice≃Slice f .is-precat-iso.has-is-ff {x} {y} = is-iso→is-equiv λ where
+  .is-iso.from g .map .map → g .map
+  .is-iso.from g .map .com → car (sym (y .map .com)) ∙∙ pullr (g .com) ∙∙ x .map .com
+  .is-iso.from g .com      → ext (g .com)
+  .is-iso.rinv _           → ext refl
+  .is-iso.linv _           → ext refl
 
-```agda
-Twice⊣Slice : (f : Hom a b) → Twice-slice f ⊣ Slice-twice f
-Twice⊣Slice f = adj where
-  adj : Twice-slice f ⊣ Slice-twice f
-  adj .unit .η x .map .map = id
-  adj .unit .η x .map .com = idr _ ∙ x .map .com
-  adj .unit .η x .com      = ext (idr _)
+open module Twice≃Slice {a} {b} (f : Hom a b) =
+  is-equivalence (is-precat-iso→is-equivalence (Twice≃Slice f))
+  renaming (F⁻¹ to Slice-twice; F⊣F⁻¹ to Twice⊣Slice) using () public
 
-  adj .unit .is-natural x y f   = ext id-comm-sym
-
-  adj .counit .η x .map         = id
-  adj .counit .η x .com         = idr _
-  adj .counit .is-natural x y f = ext id-comm-sym
-
-  adj .zig = ext (idr _)
-  adj .zag = ext (idr _)
+Twice≡Slice : (f : Hom a b) → Slice (Slice C b) (cut f) ≡ Slice C a
+Twice≡Slice f = Precategory-path (Twice-slice f) (Twice≃Slice f)
 ```

--- a/src/Cat/Total/Instances/Reflective.lagda.md
+++ b/src/Cat/Total/Instances/Reflective.lagda.md
@@ -62,12 +62,13 @@ composition of our reflector and the left adjoint to yoneda for $A$.
 
 ```agda
   L' : Functor (PSh ℓ C) C
-  L' = L F∘ (さB F∘ precompose L.op)
+  L' = L F∘ さB F∘ precompose L.op
 
   L'⊣ι' : L' ⊣ ι'
-  L'⊣ι' = LF⊣GR
-    (LF⊣GR (precomposite-adjunction (opposite-adjunction adj)) B-total.has-よ-adj)
-    adj
+  L'⊣ι' =
+    (precomposite-adjunction (opposite-adjunction adj)
+    ∘⊣ B-total.has-よ-adj)
+    ∘⊣ adj
 
 reflective-total→is-total : is-total C
 reflective-total→is-total .さ = L'

--- a/src/Topoi/Base.lagda.md
+++ b/src/Topoi/Base.lagda.md
@@ -582,8 +582,8 @@ functor.
         (Sliced-lex T.L-lex))
       (right-adjoint→lex (slice→total-is-equiv .is-equivalence.F⊣F⁻¹))
 
-  Slice-topos .L⊣ι = LF⊣GR (is-equivalence.F⁻¹⊣F slice→total-is-equiv)
-                           (Sliced-adjoints T.L⊣ι)
+  Slice-topos .L⊣ι = is-equivalence.F⁻¹⊣F slice→total-is-equiv
+                     ∘⊣ Sliced-adjoints T.L⊣ι
 ```
 
 # Geometric morphisms
@@ -670,7 +670,7 @@ f G∘ g = mk where
   mk : Geom[ _ , _ ]
   Inv[ mk ] = Inv[ g ] F∘ Inv[ f ]
   Dir[ mk ] = Dir[ f ] F∘ Dir[ g ]
-  mk .Inv⊣Dir = LF⊣GR f.Inv⊣Dir g.Inv⊣Dir
+  mk .Inv⊣Dir = f.Inv⊣Dir ∘⊣ g.Inv⊣Dir
 ```
 
 The composition of two left-exact functors is again left-exact, so


### PR DESCRIPTION
Shows that pullbacks and other connected limits in slice categories are created by the forgetful functor, then transfers this to dependent sums using `Twice≃Slice`, Among Other Small Things™.