### PR TITLE
web: Add search field on narrow screens

### DIFF
--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -340,6 +340,18 @@ article {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: var(--parskip);
+
+    #article-nav-left {
+      display: flex;
+      gap: 16px;
+
+      #narrow-search-btn {
+        background-color: transparent;
+        border: none;
+        font-size: 24px;
+      }
+    }
   }
 
   > p {
@@ -450,17 +462,6 @@ kbd {
       justify-content: center;
     }
   }
-}
-
-#article-nav-left {
-  display: flex;
-  gap: 16px;
-}
-
-#narrow-search-btn {
-  background-color: transparent;
-  border: none;
-  font-size: 24px;
 }
 
 

--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -452,6 +452,17 @@ kbd {
   }
 }
 
+#article-nav-left {
+  display: flex;
+  gap: 16px;
+}
+
+#narrow-search-btn {
+  background-color: transparent;
+  border: none;
+  font-size: 24px;
+}
+
 
 @include mixins.widescreen {
   .narrow-only {

--- a/support/web/js/prompt.tsx
+++ b/support/web/js/prompt.tsx
@@ -351,10 +351,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  const searchInputProxy = document.getElementById("search-box-proxy") as HTMLInputElement | null;
-  if (searchInputProxy) {
-    searchInputProxy.addEventListener("focus", () => startSearch());
-  }
+  document.getElementById("search-box-proxy")?.addEventListener("focus", () => startSearch())
+  document.getElementById("narrow-search-box-proxy")?.addEventListener("focus", () => startSearch())
+
 
   document.addEventListener("keydown", e => {
     if (e.key == "k" && isShortcut(e)) {

--- a/support/web/js/prompt.tsx
+++ b/support/web/js/prompt.tsx
@@ -352,7 +352,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("search-box-proxy")?.addEventListener("focus", () => startSearch())
-  document.getElementById("narrow-search-box-proxy")?.addEventListener("focus", () => startSearch())
+  document.getElementById("narrow-search-btn")?.addEventListener("click", () => startSearch())
 
 
   document.addEventListener("keydown", e => {

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -122,15 +122,11 @@
         <!-- Article navigation (narrow screens only) -->
         <div class="narrow-only" id="article-nav">
           <div id="article-nav-left">
-            <div class="mathpar">
-              <a id=logo href="$base-url$/">
-                <img alt="1Lab" src="$base-url$/static/cube-72x.png" style="display: block; margin-bottom: 1em; margin: auto;"
-                  width="32px" height="32px" />
-              </a>
-            </div>
-            <div class="mathpar js-only">
-              <button id="narrow-search-btn">🔍</button>
-            </div>
+            <a id=logo href="$base-url$/">
+              <img alt="1Lab" src="$base-url$/static/cube-72x.png" style="display: block; margin-bottom: 1em; margin: auto;"
+                width="32px" height="32px" />
+            </a>
+            <button id="narrow-search-btn" class="js-only">🔍</button>
           </div>
 
           <!-- Navbar equations control -->

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -51,7 +51,7 @@
         display: none;
       }
 
-      .search-form {
+      .js-only {
         display: none !important;
       }
     </style>
@@ -97,7 +97,7 @@
           $endif$
 
           <!-- Navbar navigation (lol) -->
-          <div class="search-form search-form-proxy mathpar" role="form">
+          <div class="search-form search-form-proxy mathpar js-only" role="form">
             <input id="search-box-proxy" type_="text" placeholder="Search..." autocomplete="off" tabindex="0" />
           </div>
 
@@ -121,18 +121,16 @@
       <article>
         <!-- Article navigation (narrow screens only) -->
         <div class="narrow-only" id="article-nav">
-          <!-- Index return anchor (only if the page is not the index) -->
-          $if(is-index)$
-          $else$
-          <noscript>
-            <div id=return>
-              <a href="$base-url$/">back to index</a>
+          <div id="article-nav-left">
+            <div class="mathpar">
+              <a id=logo href="$base-url$/">
+                <img alt="1Lab" src="$base-url$/static/cube-72x.png" style="display: block; margin-bottom: 1em; margin: auto;"
+                  width="32px" height="32px" />
+              </a>
             </div>
-          </noscript>
-          $endif$
-
-          <div class="search-form search-form-proxy mathpar" role="form">
-            <input id="narrow-search-box-proxy" type_="text" placeholder="Search..." autocomplete="off" tabindex="0" />
+            <div class="mathpar js-only">
+              <button id="narrow-search-btn">🔍</button>
+            </div>
           </div>
 
           <!-- Navbar equations control -->

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -50,6 +50,10 @@
       body span.reasoning-step .alternate {
         display: none;
       }
+
+      .search-form {
+        display: none !important;
+      }
     </style>
   </noscript>
 
@@ -120,10 +124,16 @@
           <!-- Index return anchor (only if the page is not the index) -->
           $if(is-index)$
           $else$
-          <div id=return>
-            <a href="$base-url$/">back to index</a>
-          </div>
+          <noscript>
+            <div id=return>
+              <a href="$base-url$/">back to index</a>
+            </div>
+          </noscript>
           $endif$
+
+          <div class="search-form search-form-proxy mathpar" role="form">
+            <input id="narrow-search-box-proxy" type_="text" placeholder="Search..." autocomplete="off" tabindex="0" />
+          </div>
 
           <!-- Navbar equations control -->
           <span class="equations" style="display: flex; gap: 0.25em; flex-wrap: nowrap;">


### PR DESCRIPTION
# Description

An alternative to #640 which closes #426. 

This also hides all the search fields when js is disabled (since they didn't do anything anyway), and replaces "back to index" on narrow screens with a search box when js is enabled.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
