### PR TITLE
More typos and prose fixes

### DIFF
--- a/src/Cat/Diagram/Product/Power.lagda.md
+++ b/src/Cat/Diagram/Product/Power.lagda.md
@@ -21,7 +21,7 @@ import Cat.Reasoning
 module Cat.Diagram.Product.Power where
 ```
 
-# Power {defines="power powered well-powered cotensor cotensored"}
+# Power {defines="power powered"}
 
 Powering is the formal dual to [[copowering|copower]].
 

--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -704,7 +704,7 @@ uses the universal property that yields a vertical morphism.
 
 Admittedly, the notion of Cartesian morphism is slightly artificial. It
 arises from studying the specific properties of the [[pullback functors]]
-$f^* : \cC/y \to \cC/x$ which exist in a category of pullbacks,
+$f^* : \cC/y \to \cC/x$ which exist in a category with pullbacks,
 hence the similarity in universal property!
 
 In fact, the quintessential example of a Cartesian fibration is the

--- a/src/Cat/Displayed/Instances/Simple.lagda.md
+++ b/src/Cat/Displayed/Instances/Simple.lagda.md
@@ -256,7 +256,7 @@ a right inverse.
 # Fibration structure
 
 As suggested by it's name, the simple fibration is a fibration.
-given a map $\Gamma \to Delta$ in the base, and a $(\Delta , Y)$
+given a map $\Gamma \to \Delta$ in the base, and a $(\Delta , Y)$
 upstairs, we can construct a lift by selecting $(\Gamma, Y)$ as the
 corner of the lift, and then using the second projection as the lift
 itself. Intuitively, this encodes a substitution of contexts: because

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -62,7 +62,7 @@ open Subobject public
 To make formalisation smoother, we define our own version of displayed
 morphisms in the subobject fibration, rather than reusing those of the
 fundamental self-indexing. The reason for this is quite technical: the
-type of maps in the self-indexing is only dependent (the domains and)
+type of maps in the self-indexing is only dependent on (the domains and)
 the _morphisms_ being considered, meaning nothing constrains the proofs
 that these are monomorphisms, causing unification to fail at the
 determining the full `Subobject`{.Agda}s involved.
@@ -385,7 +385,7 @@ Sub-antisym f g = Sub.make-iso f g prop! prop!
 ```
 -->
 
-There is an evident fully faithful functor from $\Sub(y) to \cB/y$ that
+There is an evident fully faithful functor from $\Sub(y) \to \cB/y$ that
 forgets the property of being monic.
 
 ```agda

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -33,7 +33,7 @@
 
 @misc{relativect,
   title   = {Foundations of Relative Category Theory},
-  url     = {https://www.jonmsterling.com/frct-003I.xml},
+  url     = {https://www.jonmsterling.com/frct-003I/},
   urldate = {2022-02-06},
   author  = {Sterling, Jonathan and Angiuli, Carlo},
   year    = {2022}


### PR DESCRIPTION
# Description

Fixes some more typos, removes some confusing definition tags, and changes a broken link.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
