### PR TITLE
Clean up APIs for terminal and initial objects

### DIFF
--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -833,6 +833,17 @@ is-contr→≃⊤ : is-contr A → A ≃ ⊤
 is-contr→≃⊤ c = is-contr→≃ c ⊤-is-contr
 ```
 
+<!--
+```agda
+is-contr≃equiv-⊤ : is-contr A ≃ (A ≃ ⊤)
+is-contr≃equiv-⊤ .fst = is-contr→≃⊤
+is-contr≃equiv-⊤ .snd = is-iso→is-equiv λ where
+  .is-iso.from e → contr (Equiv.from e tt) λ x → Equiv.η e x
+  .is-iso.rinv e → Σ-pathp refl (is-equiv-is-prop _ _ _)
+  .is-iso.linv x → is-contr-is-prop _ _
+```
+-->
+
 ### Strictness of the empty type
 
 We say that an [[initial object]] is *strict* if every map into it is an

--- a/src/1Lab/Type/Pi.lagda.md
+++ b/src/1Lab/Type/Pi.lagda.md
@@ -67,6 +67,29 @@ codomain of a dependent function by an equivalence across universe levels:
   equiv-path (k x) (f {x}) (g {x} , λ k → p k {x}) i .snd j
 ```
 
+<!--
+```agda
+Π-ap-cod₂
+  : ∀ {ℓa ℓb ℓp ℓq}
+  → {A : Type ℓa} {B : A → Type ℓb}
+  → {P : (a : A) → B a → Type ℓp}
+  → {Q : (a : A) → B a → Type ℓq}
+  → (∀ (a : A) → (b : B a) → P a b ≃ Q a b)
+  → (∀ (a : A) (b : B a) → P a b) ≃ (∀ (a : A) (b : B a) → Q a b)
+Π-ap-cod₂ e = Π-ap-cod λ x → Π-ap-cod (e x)
+
+Π-ap-cod₃
+  : ∀ {ℓa ℓb ℓc ℓp ℓq}
+  → {A : Type ℓa} {B : A → Type ℓb} {C : (a : A) → B a → Type ℓc}
+  → {P : (a : A) (b : B a) → C a b → Type ℓp}
+  → {Q : (a : A) (b : B a) → C a b → Type ℓq}
+  → (∀ (a : A) (b : B a) (c : C a b) → P a b c ≃ Q a b c)
+  → (∀ (a : A) (b : B a) (c : C a b) → P a b c) ≃ (∀ (a : A) (b : B a) (c : C a b) → Q a b c)
+Π-ap-cod₃ e = Π-ap-cod λ x → Π-ap-cod₂ (e x)
+```
+-->
+
+
 For non-dependent functions, we can easily perturb both domain and
 codomain:
 
@@ -282,5 +305,15 @@ flip f b a = f a b
 Π²-impl≃ .fst f = f _ _
 Π²-impl≃ .snd .is-eqv f .centre = strict-fibres (λ f _ _ → f) (λ {a} {b} → f {a} {b}) .fst
 Π²-impl≃ .snd .is-eqv f .paths  = strict-fibres (λ f _ _ → f) (λ {a} {b} → f {a} {b}) .snd
+
+const-fibre-prop≃
+  : ∀ {ℓa ℓb} {A : Type ℓa} {B : Type ℓb}
+  → is-prop A
+  → (a a' : A)
+  → fibre (λ (b : B) → a) a' ≃ B
+const-fibre-prop≃ {B = B} A-prop a a' =
+  fibre (λ b → a) a' ≃⟨⟩
+  B × a ≡ a'         ≃⟨ Σ-contr-snd (λ b → Path-is-hlevel' zero A-prop a a') ⟩
+  B                  ≃∎
 ```
 -->

--- a/src/1Lab/Type/Sigma.lagda.md
+++ b/src/1Lab/Type/Sigma.lagda.md
@@ -154,6 +154,27 @@ they are included for completeness. </summary>
 ```
 </details>
 
+<!--
+```agda
+Σ-ap-snd₂
+  : ∀ {ℓa ℓb ℓp ℓq}
+  → {A : Type ℓa} {B : A → Type ℓb}
+  → {P : (a : A) → B a → Type ℓp}
+  → {Q : (a : A) → B a → Type ℓq}
+  → (∀ (a : A) → (b : B a) → P a b ≃ Q a b)
+  → (Σ[ a ∈ A ] Σ[ b ∈ B a ] P a b) ≃ (Σ[ a ∈ A ] Σ[ b ∈ B a ] Q a b)
+Σ-ap-snd₂ e = Σ-ap-snd (λ a → Σ-ap-snd (e a))
+
+Σ-ap-snd₃
+  : ∀ {ℓa ℓb ℓc ℓp ℓq}
+  → {A : Type ℓa} {B : A → Type ℓb} {C : (a : A) → B a → Type ℓc}
+  → {P : (a : A) (b : B a) → C a b → Type ℓp}
+  → {Q : (a : A) (b : B a) → C a b → Type ℓq}
+  → (∀ (a : A) (b : B a) (c : C a b) → P a b c ≃ Q a b c)
+  → (Σ[ a ∈ A ] Σ[ b ∈ B a ] Σ[ c ∈ C a b ] P a b c) ≃ (Σ[ a ∈ A ] Σ[ b ∈ B a ] Σ[ c ∈ C a b ] Q a b c)
+Σ-ap-snd₃ e = Σ-ap-snd (λ a → Σ-ap-snd₂ (e a))
+```
+-->
 
 ## Paths in subtypes
 
@@ -343,5 +364,27 @@ module _ {ℓ ℓ' ℓ''} {X : Type ℓ} {Y : X → Type ℓ'} {Z : (x : X) → 
   curry≃ .fst = curry
   curry≃ .snd .is-eqv f .centre = strict-fibres uncurry f .fst
   curry≃ .snd .is-eqv f .paths  = strict-fibres uncurry f .snd
+```
+-->
+
+<!--
+```agda
+Σ-pulll
+  : ∀ {ℓa ℓb ℓc ℓx}
+  → {A : Type ℓa} {B : A → Type ℓb} {C : ∀ a → B a → Type ℓc}
+  → {X : Type ℓx}
+  → (e : (Σ[ a ∈ A ] B a) ≃ X)
+  → (Σ[ a ∈ A ] Σ[ b ∈ B a ] C a b)
+  ≃ (Σ[ x ∈ X ] C (Equiv.from e x .fst) (Equiv.from e x .snd))
+Σ-pulll e = Σ-assoc ∙e Σ-ap-fst (e e⁻¹) e⁻¹
+
+Σ-pulll3
+  : ∀ {ℓa ℓb ℓc ℓd ℓx}
+  → {A : Type ℓa} {B : A → Type ℓb} {C : ∀ a → B a → Type ℓc} {D : ∀ a b → C a b → Type ℓd}
+  → {X : Type ℓx}
+  → (e : (Σ[ a ∈ A ] Σ[ b ∈ B a ] C a b) ≃ X)
+  → (Σ[ a ∈ A ] Σ[ b ∈ B a ] Σ[ c ∈ C a b ] D a b c)
+  ≃ (Σ[ x ∈ X ] D (Equiv.from e x .fst) (Equiv.from e x .snd .fst) (Equiv.from e x .snd .snd))
+Σ-pulll3 e = Σ-ap-snd (λ _ → Σ-assoc) ∙e Σ-pulll e
 ```
 -->

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -71,9 +71,8 @@ Zero-group-is-initial (_ , G) .paths x =
   ext λ _ → sym (is-group-hom.pres-id (x .snd))
 
 Zero-group-is-terminal : is-terminal (Groups ℓ) Zero-group
-Zero-group-is-terminal _ .centre =
-  ∫hom (λ _ → lift tt) record { pres-⋆ = λ _ _ _ → lift tt }
-Zero-group-is-terminal _ .paths x = ext λ _ → refl
+Zero-group-is-terminal .is-terminal.! = ∫hom (λ _ → lift tt) (record { pres-⋆ = λ _ _ → refl })
+Zero-group-is-terminal .is-terminal.!-unique h = ext λ _ → refl
 
 Zero-group-is-zero : is-zero (Groups ℓ) Zero-group
 Zero-group-is-zero = record
@@ -255,7 +254,7 @@ Groups-finitely-complete = with-equalisers (Groups ℓ) top prod Groups-equalise
   where
     top : Terminal (Groups ℓ)
     top .Terminal.top = Zero-group
-    top .Terminal.has⊤ = Zero-group-is-terminal
+    top .Terminal.has-is-term = Zero-group-is-terminal
 
     prod : ∀ A B → Product (Groups ℓ) A B
     prod A B .Product.apex = Direct-product A B

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -61,14 +61,13 @@ Zero-group = to-group zg where
   zg .make-group.idl x = refl
 
 Zero-group-is-initial : is-initial (Groups ℓ) Zero-group
-Zero-group-is-initial (_ , G) .centre = ∫hom (λ x → G.unit) gh where
+Zero-group-is-initial .is-initial.¡ {_ , G} = ∫hom (λ x → G.unit) gh where
   module G = Group-on G
   gh : is-group-hom _ _ (λ x → G.unit)
   gh .pres-⋆ x y =
     G.unit            ≡˘⟨ G.idl ⟩
     G.unit G.⋆ G.unit ∎
-Zero-group-is-initial (_ , G) .paths x =
-  ext λ _ → sym (is-group-hom.pres-id (x .snd))
+Zero-group-is-initial .is-initial.¡-unique f = ext λ _ → is-group-hom.pres-id (f .snd)
 
 Zero-group-is-terminal : is-terminal (Groups ℓ) Zero-group
 Zero-group-is-terminal .is-terminal.! = ∫hom (λ _ → lift tt) (record { pres-⋆ = λ _ _ → refl })

--- a/src/Algebra/Quasigroup/Instances/Initial.lagda.md
+++ b/src/Algebra/Quasigroup/Instances/Initial.lagda.md
@@ -51,13 +51,13 @@ of quasigroups, as there is a unique function out of the empty type.
 
 ```agda
 Empty-quasigroup-is-initial : is-initial (Quasigroups ℓ) Empty-quasigroup
-Empty-quasigroup-is-initial A .centre .fst ()
-Empty-quasigroup-is-initial A .centre .snd .is-quasigroup-hom.pres-⋆ ()
-Empty-quasigroup-is-initial A .paths f = ext λ ()
+Empty-quasigroup-is-initial .is-initial.¡ .fst ()
+Empty-quasigroup-is-initial .is-initial.¡ .snd .is-quasigroup-hom.pres-⋆ ()
+Empty-quasigroup-is-initial .is-initial.¡-unique f = ext λ ()
 
 Initial-quasigroup : Initial (Quasigroups ℓ)
 Initial-quasigroup .Initial.bot = Empty-quasigroup
-Initial-quasigroup .Initial.has⊥ = Empty-quasigroup-is-initial
+Initial-quasigroup .Initial.has-is-init = Empty-quasigroup-is-initial
 ```
 
 In fact, the empty quasigroup is a [[strict initial object]].

--- a/src/Algebra/Ring/Cat/Initial.lagda.md
+++ b/src/Algebra/Ring/Cat/Initial.lagda.md
@@ -69,8 +69,9 @@ prove...], so here it is:
 
 ```agda
 Int-is-initial : is-initial (Rings ℓ) Liftℤ
-Int-is-initial R = contr z→r λ x → ext (lemma x) where
-  module R = Kit R
+Int-is-initial = hom-contr→is-initial λ R → contr (z→r R) λ h → ext (lemma R h) where
+  module _ (R : Ring ℓ) where
+    module R = Kit R
 ```
 
 Note that we treat 1 with care: we could have this map 1 to `1r + 0r`,
@@ -79,10 +80,10 @@ embedding. This will result in a bit more work right now, but is work
 worth doing.
 
 ```agda
-  e : Nat → ⌞ R ⌟
-  e zero          = R.0r
-  e (suc zero)    = R.1r
-  e (suc (suc x)) = R.1r R.+ e (suc x)
+    e : Nat → ⌞ R ⌟
+    e zero          = R.0r
+    e (suc zero)    = R.1r
+    e (suc (suc x)) = R.1r R.+ e (suc x)
 ```
 
 Zero gets sent to zero, and "adding one" gets sent to adding one. Is
@@ -92,32 +93,32 @@ naturals to sums in $R$, and products of naturals to products in $R$.
 We'll need this later.
 
 ```agda
-  e-suc : ∀ n → e (suc n) ≡ R.1r R.+ e n
-  e-add : ∀ m n → e (m Nat.+ n) ≡ e m R.+ e n
-  e-mul : ∀ m n → e (m Nat.* n) ≡ e m R.* e n
+    e-suc : ∀ n → e (suc n) ≡ R.1r R.+ e n
+    e-add : ∀ m n → e (m Nat.+ n) ≡ e m R.+ e n
+    e-mul : ∀ m n → e (m Nat.* n) ≡ e m R.* e n
 ```
 
 <!--
 ```agda
-  e-suc zero = sym R.+-idr
-  e-suc (suc n) = refl
+    e-suc zero = sym R.+-idr
+    e-suc (suc n) = refl
 
-  e-add zero n = sym R.+-idl
-  e-add (suc m) n =
-    e (suc m Nat.+ n)      ≡⟨ e-suc (m Nat.+ n) ⟩
-    R.1r R.+ e (m Nat.+ n) ≡⟨ ap (R.1r R.+_) (e-add m n) ⟩
-    R.1r R.+ (e m R.+ e n) ≡⟨ R.+-associative ⟩
-    (R.1r R.+ e m) R.+ e n ≡˘⟨ ap (R._+ e n) (e-suc m) ⟩
-    e (suc m) R.+ e n ∎
+    e-add zero n = sym R.+-idl
+    e-add (suc m) n =
+      e (suc m Nat.+ n)      ≡⟨ e-suc (m Nat.+ n) ⟩
+      R.1r R.+ e (m Nat.+ n) ≡⟨ ap (R.1r R.+_) (e-add m n) ⟩
+      R.1r R.+ (e m R.+ e n) ≡⟨ R.+-associative ⟩
+      (R.1r R.+ e m) R.+ e n ≡˘⟨ ap (R._+ e n) (e-suc m) ⟩
+      e (suc m) R.+ e n ∎
 
-  e-mul zero n = sym R.*-zerol
-  e-mul (suc m) n =
-    e (suc m Nat.* n)            ≡⟨ e-add n (m Nat.* n) ⟩
-    e n R.+ e (m Nat.* n)        ≡⟨ ap (e n R.+_) (e-mul m n) ⟩
-    e n R.+ e m R.* e n          ≡˘⟨ ap (R._+ (e m R.* e n)) R.*-idl ⟩
-    R.1r R.* e n R.+ e m R.* e n ≡˘⟨ R.*-distribr ⟩
-    (R.1r R.+ e m) R.* e n       ≡˘⟨ ap (R._* e n) (e-suc m) ⟩
-    (e (suc m) R.* e n) ∎
+    e-mul zero n = sym R.*-zerol
+    e-mul (suc m) n =
+      e (suc m Nat.* n)            ≡⟨ e-add n (m Nat.* n) ⟩
+      e n R.+ e (m Nat.* n)        ≡⟨ ap (e n R.+_) (e-mul m n) ⟩
+      e n R.+ e m R.* e n          ≡˘⟨ ap (R._+ (e m R.* e n)) R.*-idl ⟩
+      R.1r R.* e n R.+ e m R.* e n ≡˘⟨ R.*-distribr ⟩
+      (R.1r R.+ e m) R.* e n       ≡˘⟨ ap (R._* e n) (e-suc m) ⟩
+      (e (suc m) R.* e n) ∎
 ```
 -->
 
@@ -129,13 +130,13 @@ integers, i.e. we need $e(m) - e(n) = e(1 + m) - e(1 + n)$. This is
 annoying to show, but not _too_ annoying:
 
 ```agda
-  e-tr : ∀ m n → e m R.- e n ≡ e (suc m) R.- e (suc n)
-  e-tr m n = sym $
-    (e (suc m) R.- e (suc n))                   ≡⟨ ap₂ R._-_ (e-suc m) (e-suc n) ⟩
-    (R.1r R.+ e m) R.- (R.1r R.+ e n)           ≡⟨ ap₂ R._+_ refl (R.a.inv-comm ∙ R.+-commutes) ∙ R.+-associative ⟩
-    R.1r R.+ e m R.+ (R.- R.1r) R.+ (R.- e n)   ≡⟨ ap₂ R._+_ (R.pullr R.+-commutes ∙ R.pulll refl) refl ⟩
-    R.1r R.+ (R.- R.1r) R.+ e m R.+ (R.- e n)   ≡⟨ ap₂ R._+_ (R.eliml R.+-invr) refl ⟩
-    e m R.- e n                                 ∎
+    e-tr : ∀ m n → e m R.- e n ≡ e (suc m) R.- e (suc n)
+    e-tr m n = sym $
+      (e (suc m) R.- e (suc n))                   ≡⟨ ap₂ R._-_ (e-suc m) (e-suc n) ⟩
+      (R.1r R.+ e m) R.- (R.1r R.+ e n)           ≡⟨ ap₂ R._+_ refl (R.a.inv-comm ∙ R.+-commutes) ∙ R.+-associative ⟩
+      R.1r R.+ e m R.+ (R.- R.1r) R.+ (R.- e n)   ≡⟨ ap₂ R._+_ (R.pullr R.+-commutes ∙ R.pulll refl) refl ⟩
+      R.1r R.+ (R.- R.1r) R.+ e m R.+ (R.- e n)   ≡⟨ ap₂ R._+_ (R.eliml R.+-invr) refl ⟩
+      e m R.- e n                                 ∎
 ```
 
 We can now build the embedding $\ZZ \mono R$. It remains to show that
@@ -144,58 +145,58 @@ algebra, so I won't comment on it too much: it can be worked out on
 paper, following the ring laws.
 
 ```agda
-  ℤ↪R : Int → ⌞ R ⌟
-  ℤ↪R (pos x) = e x
-  ℤ↪R (negsuc x) = R.- (e (suc x))
+    ℤ↪R : Int → ⌞ R ⌟
+    ℤ↪R (pos x) = e x
+    ℤ↪R (negsuc x) = R.- (e (suc x))
 
-  open is-ring-hom
+    open is-ring-hom
 
-  z-nat-diff : ∀ x y → ℤ↪R (x ℕ- y) ≡ e x R.- e y
-  z-nat-diff x zero = R.intror R.inv-unit
-  z-nat-diff zero (suc y) = R.introl refl
-  z-nat-diff (suc x) (suc y) = z-nat-diff x y ∙ e-tr x y
+    z-nat-diff : ∀ x y → ℤ↪R (x ℕ- y) ≡ e x R.- e y
+    z-nat-diff x zero = R.intror R.inv-unit
+    z-nat-diff zero (suc y) = R.introl refl
+    z-nat-diff (suc x) (suc y) = z-nat-diff x y ∙ e-tr x y
 
-  z-add : ∀ x y → ℤ↪R (x +ℤ y) ≡ ℤ↪R x R.+ ℤ↪R y
-  z-add (pos x) (pos y) = e-add x y
-  z-add (pos x) (negsuc y) = z-nat-diff x (suc y)
-  z-add (negsuc x) (pos y) = z-nat-diff y (suc x) ∙ R.+-commutes
-  z-add (negsuc x) (negsuc y) =
-    R.- (e 1 R.+ e (suc x Nat.+ y))         ≡⟨ ap R.-_ (ap₂ R._+_ refl (e-add (suc x) y) ∙ R.extendl R.+-commutes) ⟩
-    R.- (e (suc x) R.+ (e 1 R.+ e y))       ≡⟨ R.a.inv-comm ⟩
-    (R.- (e 1 R.+ e y)) R.+ (R.- e (suc x)) ≡⟨ R.+-commutes ⟩
-    (R.- e (suc x)) R.+ (R.- (e 1 R.+ e y)) ≡⟨ ap₂ R._+_ refl (ap R.-_ (sym (e-add 1 y))) ⟩
-    (R.- e (suc x)) R.+ (R.- e (1 Nat.+ y)) ∎
+    z-add : ∀ x y → ℤ↪R (x +ℤ y) ≡ ℤ↪R x R.+ ℤ↪R y
+    z-add (pos x) (pos y) = e-add x y
+    z-add (pos x) (negsuc y) = z-nat-diff x (suc y)
+    z-add (negsuc x) (pos y) = z-nat-diff y (suc x) ∙ R.+-commutes
+    z-add (negsuc x) (negsuc y) =
+      R.- (e 1 R.+ e (suc x Nat.+ y))         ≡⟨ ap R.-_ (ap₂ R._+_ refl (e-add (suc x) y) ∙ R.extendl R.+-commutes) ⟩
+      R.- (e (suc x) R.+ (e 1 R.+ e y))       ≡⟨ R.a.inv-comm ⟩
+      (R.- (e 1 R.+ e y)) R.+ (R.- e (suc x)) ≡⟨ R.+-commutes ⟩
+      (R.- e (suc x)) R.+ (R.- (e 1 R.+ e y)) ≡⟨ ap₂ R._+_ refl (ap R.-_ (sym (e-add 1 y))) ⟩
+      (R.- e (suc x)) R.+ (R.- e (1 Nat.+ y)) ∎
 
-  z-mul : ∀ x y → ℤ↪R (x *ℤ y) ≡ ℤ↪R x R.* ℤ↪R y
-  z-mul (pos x) (pos y) =
-    ℤ↪R (assign pos (x Nat.* y)) ≡⟨ ap ℤ↪R (assign-pos (x Nat.* y)) ⟩
-    e (x Nat.* y)                ≡⟨ e-mul x y ⟩
-    (e x R.* e y)                ∎
-  z-mul (posz) (negsuc y) = sym R.*-zerol
-  z-mul (possuc x) (negsuc y) =
-    R.- e (suc x Nat.* suc y)     ≡⟨ ap R.-_ (e-mul (suc x) (suc y)) ⟩
-    R.- (e (suc x) R.* e (suc y)) ≡˘⟨ R.*-negater ⟩
-    e (suc x) R.* (R.- e (suc y)) ∎
-  z-mul (negsuc x) (posz) =
-    ℤ↪R (assign neg (x Nat.* 0)) ≡⟨ ap ℤ↪R (ap (assign neg) (Nat.*-zeror x)) ⟩
-    ℤ↪R 0                        ≡⟨ sym R.*-zeror ⟩
-    ℤ↪R (negsuc x) R.* R.0r      ∎
-  z-mul (negsuc x) (possuc y) =
-    R.- e (suc x Nat.* suc y)     ≡⟨ ap R.-_ (e-mul (suc x) (suc y)) ⟩
-    R.- (e (suc x) R.* e (suc y)) ≡⟨ sym R.*-negatel ⟩
-    (R.- e (suc x)) R.* e (suc y) ∎
-  z-mul (negsuc x) (negsuc y) =
-    e (suc x Nat.* suc y)               ≡⟨ e-mul (suc x) (suc y) ⟩
-    e (suc x) R.* e (suc y)             ≡˘⟨ R.inv-inv ⟩
-    R.- (R.- (e (suc x) R.* e (suc y))) ≡˘⟨ ap R.-_ R.*-negater ⟩
-    R.- (e (suc x) R.* ℤ↪R (negsuc y))  ≡˘⟨ R.*-negatel ⟩
-    ℤ↪R (negsuc x) R.* ℤ↪R (negsuc y)   ∎
+    z-mul : ∀ x y → ℤ↪R (x *ℤ y) ≡ ℤ↪R x R.* ℤ↪R y
+    z-mul (pos x) (pos y) =
+      ℤ↪R (assign pos (x Nat.* y)) ≡⟨ ap ℤ↪R (assign-pos (x Nat.* y)) ⟩
+      e (x Nat.* y)                ≡⟨ e-mul x y ⟩
+      (e x R.* e y)                ∎
+    z-mul (posz) (negsuc y) = sym R.*-zerol
+    z-mul (possuc x) (negsuc y) =
+      R.- e (suc x Nat.* suc y)     ≡⟨ ap R.-_ (e-mul (suc x) (suc y)) ⟩
+      R.- (e (suc x) R.* e (suc y)) ≡˘⟨ R.*-negater ⟩
+      e (suc x) R.* (R.- e (suc y)) ∎
+    z-mul (negsuc x) (posz) =
+      ℤ↪R (assign neg (x Nat.* 0)) ≡⟨ ap ℤ↪R (ap (assign neg) (Nat.*-zeror x)) ⟩
+      ℤ↪R 0                        ≡⟨ sym R.*-zeror ⟩
+      ℤ↪R (negsuc x) R.* R.0r      ∎
+    z-mul (negsuc x) (possuc y) =
+      R.- e (suc x Nat.* suc y)     ≡⟨ ap R.-_ (e-mul (suc x) (suc y)) ⟩
+      R.- (e (suc x) R.* e (suc y)) ≡⟨ sym R.*-negatel ⟩
+      (R.- e (suc x)) R.* e (suc y) ∎
+    z-mul (negsuc x) (negsuc y) =
+      e (suc x Nat.* suc y)               ≡⟨ e-mul (suc x) (suc y) ⟩
+      e (suc x) R.* e (suc y)             ≡˘⟨ R.inv-inv ⟩
+      R.- (R.- (e (suc x) R.* e (suc y))) ≡˘⟨ ap R.-_ R.*-negater ⟩
+      R.- (e (suc x) R.* ℤ↪R (negsuc y))  ≡˘⟨ R.*-negatel ⟩
+      ℤ↪R (negsuc x) R.* ℤ↪R (negsuc y)   ∎
 
-  z→r : Rings.Hom Liftℤ R
-  z→r .fst (lift x) = ℤ↪R x
-  z→r .snd .pres-id = refl
-  z→r .snd .pres-+ (lift x) (lift y) = z-add x y
-  z→r .snd .pres-* (lift x) (lift y) = z-mul x y
+    z→r : Rings.Hom Liftℤ R
+    z→r .fst (lift x) = ℤ↪R x
+    z→r .snd .pres-id = refl
+    z→r .snd .pres-+ (lift x) (lift y) = z-add x y
+    z→r .snd .pres-* (lift x) (lift y) = z-mul x y
 ```
 
 The last thing we must show is that this is the _unique_ ring
@@ -215,14 +216,14 @@ and that last expression is pretty exactly what our canonical map
 evaluates to on $n$. So we're done!
 
 ```agda
-  module _ (f : Rings.Hom Liftℤ R) where
-    private module f = is-ring-hom (f .snd)
+    module _ (f : Rings.Hom Liftℤ R) where
+      private module f = is-ring-hom (f .snd)
 
-    f-pos : ∀ x → e x ≡ f · lift (pos x)
-    f-pos zero = sym f.pres-0
-    f-pos (suc x) = e-suc x ∙ sym (f.pres-+ (lift 1) (lift (pos x)) ∙ ap₂ R._+_ f.pres-id (sym (f-pos x)))
+      f-pos : ∀ x → e x ≡ f · lift (pos x)
+      f-pos zero = sym f.pres-0
+      f-pos (suc x) = e-suc x ∙ sym (f.pres-+ (lift 1) (lift (pos x)) ∙ ap₂ R._+_ f.pres-id (sym (f-pos x)))
 
-    lemma : ∀ i → z→r · lift i ≡ f · lift i
-    lemma (pos x) = f-pos x
-    lemma (negsuc x) = sym (f.pres-neg {lift (possuc x)} ∙ ap R.-_ (sym (f-pos (suc x))))
+      lemma : ∀ i → z→r · lift i ≡ f · lift i
+      lemma (pos x) = f-pos x
+      lemma (negsuc x) = sym (f.pres-neg {lift (possuc x)} ∙ ap R.-_ (sym (f-pos (suc x))))
 ```

--- a/src/Algebra/Ring/Module/Action.lagda.md
+++ b/src/Algebra/Ring/Module/Action.lagda.md
@@ -8,6 +8,7 @@ open import Algebra.Group
 open import Algebra.Ring
 
 open import Cat.Displayed.Univalence.Thin
+open import Cat.Diagram.Initial
 open import Cat.Abelian.Base
 open import Cat.Abelian.Endo
 open import Cat.Prelude hiding (_+_)
@@ -125,5 +126,7 @@ former!
 
 ```agda
 ℤ-module-unique : ∀ {ℓ} (G : Abelian-group ℓ) → is-contr (Ring-action Liftℤ (G .snd))
-ℤ-module-unique G = Equiv→is-hlevel 0 (Action≃Hom Liftℤ G) (Int-is-initial _)
+ℤ-module-unique G =
+  Equiv→is-hlevel 0 (Action≃Hom Liftℤ G)
+  $ is-initial→hom-contr Int-is-initial _
 ```

--- a/src/Algebra/Ring/Module/Category.lagda.md
+++ b/src/Algebra/Ring/Module/Category.lagda.md
@@ -209,9 +209,9 @@ R-Mod-is-additive .has-terminal = term where
 
   term : Terminal (R-Mod R _)
   term .Terminal.top = ∅ᴹ
-  term .Terminal.has⊤ x .centre .fst _ = lift tt
-  term .Terminal.has⊤ x .centre .snd .linear r s t = refl
-  term .Terminal.has⊤ x .paths r = ext λ _ → refl
+  term .Terminal.has-is-term .is-terminal.! .fst _ = lift tt
+  term .Terminal.has-is-term .is-terminal.! .snd .linear r s t = refl
+  term .Terminal.has-is-term .is-terminal.!-unique r = ext λ _ → refl
 ```
 
 For the direct products, on the other hand, we have to do a bit more

--- a/src/Algebra/Ring/Solver.agda
+++ b/src/Algebra/Ring/Solver.agda
@@ -19,6 +19,7 @@ open import Algebra.Group.Ab
 open import Algebra.Group
 open import Algebra.Ring
 
+open import Cat.Diagram.Initial
 open import Cat.Displayed.Total
 open import Cat.Prelude hiding (_+_ ; _*_ ; _-_)
 
@@ -38,13 +39,14 @@ open ∫Hom
 module Algebra.Ring.Solver where
 
 module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
+  open is-initial
   private
     R' : Ring _
     R' = record { fst = el _ (CRing-on.has-is-set cring) ; snd = CRing-on.has-ring-on cring }
 
     module R = Kit R'
 
-    ℤ↪R-rh = Int-is-initial R' .centre
+    ℤ↪R-rh = Int-is-initial .¡ {R'}
     module ℤ↪R = is-ring-hom (ℤ↪R-rh .snd)
 
     open CRing-on cring using (*-commutes)
@@ -56,7 +58,7 @@ module Impl {ℓ} {R : Type ℓ} (cring : CRing-on R) where
     : {h' : Int → R}
     → is-ring-hom (Liftℤ {ℓ} .snd) (R' .snd) (h' ⊙ lower)
     → ∀ x → embed-coe x ≡ h' x
-  embed-lemma p x = Int-is-initial R' .paths (∫hom _ p) ·ₚ lift x
+  embed-lemma p x = sym $ Int-is-initial .¡-unique (∫hom _ p) ·ₚ lift x
 
   data Poly   : Nat → Type ℓ
   data Normal : Nat → Type ℓ

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -10,6 +10,7 @@ open import Cat.Diagram.Coequaliser
 open import Cat.Diagram.Biproduct
 open import Cat.Diagram.Coproduct
 open import Cat.Diagram.Terminal
+open import Cat.Diagram.Initial
 open import Cat.Diagram.Product
 open import Cat.Displayed.Total
 open import Cat.Instances.Slice
@@ -151,17 +152,21 @@ module _ {o ℓ} {C : Precategory o ℓ} (A : Ab-category C) where
   private module A = Ab-category A
 
   id-zero→zero : ∀ {X} → A.id {X} ≡ A.0m → is-zero C X
-  id-zero→zero idm .is-zero.has-is-initial B = contr A.0m λ h → sym $
-    h                                ≡⟨ A.intror refl ⟩
-    h A.∘ A.id                       ≡⟨ A.refl⟩∘⟨ idm ⟩
-    h A.∘ A.0m                       ≡⟨ A.∘-zero-r ⟩
-    A.0m                             ∎
-  id-zero→zero idm .is-zero.has-is-terminal .is-terminal.! = A.0m
-  id-zero→zero idm .is-zero.has-is-terminal .is-terminal.!-unique = λ h →
-    h                              ≡⟨ A.introl refl ⟩
-    A.id A.∘ h                     ≡⟨ idm A.⟩∘⟨refl ⟩
-    A.0m A.∘ h                     ≡⟨ A.∘-zero-l ⟩
-    A.0m                           ∎
+  {-# INLINE id-zero→zero #-}
+  id-zero→zero idm = to-is-zero $ record
+    { ! = A.0m
+    ; ¡ = A.0m
+    ; !-unique = λ h →
+      h          ≡⟨ A.introl refl ⟩
+      A.id A.∘ h ≡⟨ idm A.⟩∘⟨refl ⟩
+      A.0m A.∘ h ≡⟨ A.∘-zero-l ⟩
+      A.0m       ∎
+    ; ¡-unique = λ h →
+      h          ≡⟨ A.intror refl ⟩
+      h A.∘ A.id ≡⟨ A.refl⟩∘⟨ idm ⟩
+      h A.∘ A.0m ≡⟨ A.∘-zero-r ⟩
+      A.0m       ∎
+    }
 ```
 
 Perhaps the simplest example of an $\Ab$-category is.. any ring! In the
@@ -204,7 +209,7 @@ record is-additive {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ lsuc ℓ) where
   module ∅ = Zero ∅
 
   0m-unique : ∀ {A B} → ∅.zero→ {A} {B} ≡ 0m
-  0m-unique = ap₂ _∘_ (∅.has⊥ _ .paths _) refl ∙ ∘-zero-l
+  0m-unique = ap₂ _∘_ (∅.¡-unique _) refl ∙ ∘-zero-l
 ```
 
 Coincidence of finite products and finite coproducts leads to an object
@@ -412,7 +417,7 @@ monomorphism].
           path : f ∘ kernel f .Kernel.kernel ≡ f ∘ 0m
           path = Ker.equal f
             ∙∙ ∅.zero-∘r _
-            ∙∙ ap₂ _∘_ (∅.has⊥ _ .paths 0m) refl
+            ∙∙ ap₂ _∘_ (sym $ ∅.¡-unique 0m) refl
             ∙∙ ∘-zero-l ∙∙ sym ∘-zero-r
 ```
 -->

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -156,7 +156,8 @@ module _ {o ℓ} {C : Precategory o ℓ} (A : Ab-category C) where
     h A.∘ A.id                       ≡⟨ A.refl⟩∘⟨ idm ⟩
     h A.∘ A.0m                       ≡⟨ A.∘-zero-r ⟩
     A.0m                             ∎
-  id-zero→zero idm .is-zero.has-is-terminal x = contr A.0m λ h → sym $
+  id-zero→zero idm .is-zero.has-is-terminal .is-terminal.! = A.0m
+  id-zero→zero idm .is-zero.has-is-terminal .is-terminal.!-unique = λ h →
     h                              ≡⟨ A.introl refl ⟩
     A.id A.∘ h                     ≡⟨ idm A.⟩∘⟨refl ⟩
     A.0m A.∘ h                     ≡⟨ A.∘-zero-l ⟩
@@ -199,7 +200,7 @@ record is-additive {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ lsuc ℓ) where
   ∅ : Zero C
   ∅ .Zero.∅ = has-terminal .Terminal.top
   ∅ .Zero.has-is-zero = id-zero→zero has-ab $
-    is-contr→is-prop (has-terminal .Terminal.has⊤ _) _ _
+    Terminal.!-unique₂ has-terminal id 0m
   module ∅ = Zero ∅
 
   0m-unique : ∀ {A B} → ∅.zero→ {A} {B} ≡ 0m
@@ -432,8 +433,7 @@ the canonical subobject inclusion $\ker(f) \to B$.
           path : ∅.zero→ ∘ proj' ≡ Coker.coeq f ∘ proj'
           path = Coker.unique₂ (Ker.kernel f)
             {e' = 0m} (∘-zero-r ∙ sym ∘-zero-l)
-            (pushl (∅.zero-∘r _) ∙ pulll ( ap₂ _∘_ refl (∅.has⊤ _ .paths 0m)
-                                               ∙ ∘-zero-r)
+            (pushl (∅.zero-∘r _) ∙ pulll (∘-zero-r)
                  ∙ ∘-zero-l)
             (pullr (Coker.factors (Ker.kernel f)) ∙ sym (Coker.coequal _)
                  ∙ ∘-zero-r)

--- a/src/Cat/Abelian/Functor.lagda.md
+++ b/src/Cat/Abelian/Functor.lagda.md
@@ -86,7 +86,7 @@ Ab-functor-pres-∅
 Ab-functor-pres-∅ {A = A} {B = B} F ∅A =
   id-zero→zero B $
     B.id     ≡˘⟨ F.F-id ⟩
-    F.₁ A.id ≡⟨ ap F.₁ (is-contr→is-prop (Zero.has⊤ ∅A (Zero.∅ ∅A)) _ _) ⟩
+    F.₁ A.id ≡⟨ ap F.₁ (Zero.!-unique₂ ∅A A.id A.0m) ⟩
     F.₁ A.0m ≡⟨ F.F-0m ⟩
     B.0m     ∎
   where

--- a/src/Cat/Abelian/Images.lagda.md
+++ b/src/Cat/Abelian/Images.lagda.md
@@ -111,12 +111,13 @@ commutes.
 ```agda
   im : Image C f
   im .Initial.bot = the-img
-  im .Initial.has⊥ other = contr factor unique where
-    factor : ↓Hom (!Const (cut f)) Forget-full-subcat the-img other
-    factor .top = tt
-    factor .bot ./-Hom.map =
-        Coker.universal (Ker.kernel f) {e' = other .map .map} path
-      ∘ coker-ker≃ker-coker f .is-invertible.inv
+  im .Initial.has-is-init = hom-contr→is-initial (λ other → contr (factor other) (unique other)) where
+    module _ (other : ↓Obj (!Const (cut f)) Forget-full-subcat) where
+      factor : ↓Hom (!Const (cut f)) Forget-full-subcat the-img other
+      factor .top = tt
+      factor .bot ./-Hom.map =
+          Coker.universal (Ker.kernel f) {e' = other .map .map} path
+        ∘ coker-ker≃ker-coker f .is-invertible.inv
 ```
 
 Observe that by the universal property of $\coker (\ker f)$^[hence of
@@ -125,14 +126,14 @@ we have a map $q : A \to X$ such that $0 = q\ker f$, then we can obtain
 a (unique) map $\coker (\ker f) \to X$ s.t. the triangle above commutes!
 
 ```agda
-      where abstract
-        path : other .map .map ∘ 0m ≡ other .map .map ∘ kernel f .Kernel.kernel
-        path = other .cod .snd _ _ $ sym $
-             pulll (other .map .com)
-          ∙∙ Ker.equal f
-          ∙∙ ∅.zero-∘r _
-          ∙∙ 0m-unique
-          ∙∙ sym (ap₂ _∘_ refl ∘-zero-r ∙ ∘-zero-r)
+        where abstract
+          path : other .map .map ∘ 0m ≡ other .map .map ∘ kernel f .Kernel.kernel
+          path = other .cod .snd _ _ $ sym $
+               pulll (other .map .com)
+            ∙∙ Ker.equal f
+            ∙∙ ∅.zero-∘r _
+            ∙∙ 0m-unique
+            ∙∙ sym (ap₂ _∘_ refl ∘-zero-r ∙ ∘-zero-r)
 ```
 
 To satisfy that equation, observe that since $i'$ is monic, it suffices
@@ -145,22 +146,22 @@ is the image of $f$.
 <summary>Here's the tedious isomorphism algebra.</summary>
 
 ```agda
-    factor .bot ./-Hom.com = invertible→epic (coker-ker≃ker-coker f) _ _ $
-      Coker.unique₂ (Ker.kernel f)
-        (sym (Ker.equal f ∙ ∅.zero-∘r _ ∙ 0m-unique ∙ sym ∘-zero-r))
-        (ap₂ _∘_ ( sym (assoc _ _ _)
-                        ∙ ap₂ _∘_ refl (cancelr
-                          (coker-ker≃ker-coker f .is-invertible.invr))) refl
-              ∙ pullr (Coker.factors _) ∙ other .map .com)
-        (sym (decompose f .snd ∙ assoc _ _ _))
-    factor .com = /-Hom-path $ sym $ other .cod .snd _ _ $
-      pulll (factor .bot .com)
-      ∙ the-img .map .com
-      ∙∙ sym (other .map .com)
-      ∙∙ ap (other .cod .fst .map ∘_) (intror refl)
+      factor .bot ./-Hom.com = invertible→epic (coker-ker≃ker-coker f) _ _ $
+        Coker.unique₂ (Ker.kernel f)
+          (sym (Ker.equal f ∙ ∅.zero-∘r _ ∙ 0m-unique ∙ sym ∘-zero-r))
+          (ap₂ _∘_ ( sym (assoc _ _ _)
+                          ∙ ap₂ _∘_ refl (cancelr
+                            (coker-ker≃ker-coker f .is-invertible.invr))) refl
+                ∙ pullr (Coker.factors _) ∙ other .map .com)
+          (sym (decompose f .snd ∙ assoc _ _ _))
+      factor .com = /-Hom-path $ sym $ other .cod .snd _ _ $
+        pulll (factor .bot .com)
+        ∙ the-img .map .com
+        ∙∙ sym (other .map .com)
+        ∙∙ ap (other .cod .fst .map ∘_) (intror refl)
 
-    unique : ∀ x → factor ≡ x
-    unique x = ↓Hom-path _ _ refl $ /-Hom-path $ other .cod .snd _ _ $
-      sym (x .bot .com ∙ sym (factor .bot .com))
+      unique : ∀ x → factor ≡ x
+      unique x = ↓Hom-path _ _ refl $ /-Hom-path $ other .cod .snd _ _ $
+        sym (x .bot .com ∙ sym (factor .bot .com))
 ```
 </details>

--- a/src/Cat/Abelian/Instances/Ab.lagda.md
+++ b/src/Cat/Abelian/Instances/Ab.lagda.md
@@ -49,9 +49,9 @@ direct sums.
 Ab-is-additive : is-additive (Ab ℓ)
 Ab-is-additive .has-ab = Ab-ab-category
 Ab-is-additive .has-terminal .top = from-commutative-group (Zero-group {ℓ}) (λ x y → refl)
-Ab-is-additive .has-terminal .has⊤ x =
-  contr (∫hom (λ _ → lift tt) (record { pres-⋆ = λ x y i → lift tt }))
-    λ x → ext λ _ → refl
+Ab-is-additive .has-terminal .has-is-term .is-terminal.! .fst _ = lift tt
+Ab-is-additive .has-terminal .has-is-term .is-terminal.! .snd = record { pres-⋆ = λ _ _ → refl }
+Ab-is-additive .has-terminal .has-is-term .is-terminal.!-unique h = ext λ _ → refl
 
 Ab-is-additive .has-prods A B .apex = A ⊕ B
 Ab-is-additive .has-prods A B .π₁ = _

--- a/src/Cat/Cartesian.lagda.md
+++ b/src/Cat/Cartesian.lagda.md
@@ -75,12 +75,16 @@ comparison map is an isomorphism.
   record Cartesian-functor : Type (o ⊔ o' ⊔ ℓ ⊔ ℓ') where
     field
       pres-products : ∀ a b → D.is-invertible (product-comparison a b)
-      pres-terminal : is-terminal D (F.₀ C.top)
+      pres-terminal : D.is-invertible (D.! {F.₀ C.top})
 
     image-is-product
       : ∀ {a b} → is-product D {A = F.₀ a} {B = F.₀ b} (F.₁ C.π₁) (F.₁ C.π₂)
     image-is-product = is-product-iso-apex (pres-products _ _)
       D.π₁∘⟨⟩ D.π₂∘⟨⟩ D.has-is-product
+
+    image-is-terminal
+      : is-terminal D (F.₀ C.top)
+    image-is-terminal = !-invertible→is-terminal D.has-is-term pres-terminal
 ```
 
 <!--

--- a/src/Cat/CartesianClosed/Free.lagda.md
+++ b/src/Cat/CartesianClosed/Free.lagda.md
@@ -150,7 +150,8 @@ module _ where
 
   Free-terminal : Terminal Free-ccc
   Free-terminal .top    = `⊤
-  Free-terminal .has⊤ x = contr `! `!-η
+  Free-terminal .has-is-term .is-terminal.! = `!
+  Free-terminal .has-is-term .is-terminal.!-unique h = sym (`!-η h)
 
   open Cartesian-category using (products ; terminal)
   Free-cartesian : Cartesian-category Free-ccc
@@ -1184,8 +1185,10 @@ Tm-cartesian .pres-products a b = Sem.make-invertible
   (NT (elim! (λ a p q → p `, q)) λ x y f → ext λ p q → sym (Syn.⟨⟩∘ _))
   (ext (λ i a b → `π₁β ,ₚ `π₂β))
   (ext (λ i x → sym `πη))
-Tm-cartesian .pres-terminal x .centre  = NT (λ _ _ → `!) (λ x y f → ext λ a → `!-η _)
-Tm-cartesian .pres-terminal x .paths a = ext λ i x → `!-η _
+Tm-cartesian .pres-terminal = Sem.make-invertible
+  (NT (λ _ _ → `!) λ x y f → ext (λ _ → `!-η _))
+  (ext (λ _ _ → refl))
+  (ext (λ _ _ → `!-η _))
 ```
 
 However, there is an off-the-shelf solution we can reach for: since

--- a/src/Cat/CartesianClosed/Solver.lagda.md
+++ b/src/Cat/CartesianClosed/Solver.lagda.md
@@ -278,9 +278,9 @@ ren-⟦⟧ₙ ρ (lam t) =
 
 ren-⟦⟧ₙ ρ (pair a b) = ap₂ ⟨_,_⟩ (ren-⟦⟧ₙ ρ a) (ren-⟦⟧ₙ ρ b) ∙ sym (⟨⟩∘ _)
 ren-⟦⟧ₙ ρ (ne x) = ren-⟦⟧ₛ ρ x
-ren-⟦⟧ₙ ρ unit   = !-unique _
+ren-⟦⟧ₙ ρ unit   = sym (!-unique _)
 
-ren-⟦⟧ᵣ ρ ∅       = !-unique _
+ren-⟦⟧ᵣ ρ ∅       = sym (!-unique _)
 ren-⟦⟧ᵣ ρ (σ , n) = ap₂ ⟨_,_⟩ (ren-⟦⟧ᵣ ρ σ) (ren-⟦⟧ₙ ρ n) ∙ sym (⟨⟩∘ _)
 
 Tyᵖ : (τ : Ty) (Γ : Cx) → Hom ⟦ Γ ⟧ᶜ ⟦ τ ⟧ᵗ → Type (o ⊔ ℓ)
@@ -349,7 +349,7 @@ reifyᵖ-correct {τ = τ `⇒ σ} {h = h} ν =
     ≡˘⟨ unique _ refl ⟩
   h ∎
 reifyᵖ-correct {τ = ` x} d = d .snd
-reifyᵖ-correct {τ = `⊤}  d = !-unique _
+reifyᵖ-correct {τ = `⊤}  d = sym (!-unique _)
 
 private
   tickᵖ : ∀ {x y h} (m : Hom ⟦ x ⟧ᵗ ⟦ y ⟧ᵗ) → Tyᵖ x Γ h → Tyᵖ y Γ (m ∘ h)

--- a/src/Cat/Diagram/Colimit/Cocone.lagda.md
+++ b/src/Cat/Diagram/Colimit/Cocone.lagda.md
@@ -155,6 +155,7 @@ category we have just constructed.
     → is-initial Cocones K
     → is-colimit F (Cocone.coapex K) (Cocone→cocone K)
   is-initial-cocone→is-colimit {K = K} init = to-is-colimitp colim refl where
+    module K = is-initial init
     open make-is-colimit
     open Cocone
     open Cocone-hom
@@ -162,10 +163,9 @@ category we have just constructed.
     colim : make-is-colimit F (Cocone.coapex K)
     colim .ψ = K .ψ
     colim .commutes = K .commutes
-    colim .universal eta p = init (cocone _ eta p) .centre .map
-    colim .factors eta p = init (cocone _ eta p) .centre .com _
-    colim .unique eta p other q =
-      ap map (sym (init (cocone _ eta p) .paths (cocone-hom other q)))
+    colim .universal eta p = K.¡ {cocone _ eta p} .map
+    colim .factors eta p = K.¡ .com _
+    colim .unique eta p other q = ap map $ K.¡-unique (cocone-hom other q)
 ```
 
 To finish concretising the correspondence, note that this process is
@@ -183,15 +183,15 @@ invertible: From a colimit, we can extract an initial cocone.
 </summary>
 
 ```agda
-  is-colimit→is-initial-cocone {x  = x} L K = init where
-    module L = is-colimit L
-    module K = Cocone K
-    open Cocone-hom
-
-    init : is-contr (Cocone-hom (cocone x L.ψ L.commutes) K)
-    init .centre .map   = L.universal K.ψ K.commutes
-    init .centre .com _ = L.factors K.ψ K.commutes
-    init .paths f =
-      Cocone-hom-path (sym (L.unique K.ψ K.commutes (f .map) (f .com)))
+  {-# INLINE is-colimit→is-initial-cocone #-}
+  is-colimit→is-initial-cocone {x  = x} L = record
+    { ¡ = λ {K} →
+      cocone-hom (L.universal (K .ψ) (K .commutes)) (λ _ → L.factors (K .ψ) (K .commutes))
+    ; ¡-unique = λ f → Cocone-hom-path (L.unique _ _ (f .map) (f .com))
+    }
+    where
+      module L = is-colimit L
+      open Cocone
+      open Cocone-hom
 ```
 </details>

--- a/src/Cat/Diagram/Colimit/Finite.lagda.md
+++ b/src/Cat/Diagram/Colimit/Finite.lagda.md
@@ -165,11 +165,12 @@ A coproduct is a pushout under a span whose apex is the initial object.
     : ∀ {P X Y I} {in1 : Hom X P} {in2 : Hom Y P} {f : Hom I X} {g : Hom I Y}
     → is-initial C I → is-pushout C f in1 g in2 → is-coproduct C in1 in2
   initial-pushout→coproduct {in1 = in1} {in2} {f} {g} init po = coprod where
+      module init = is-initial init
       module Po = is-pushout po
 
       coprod : is-coproduct C in1 in2
       coprod .is-coproduct.[_,_] in1' in2' =
-        Po.universal {i₁' = in1'} {i₂' = in2'} (is-contr→is-prop (init _) _ _)
+        Po.universal (init.¡-unique₂ (in1' ∘ f) (in2' ∘ g))
       coprod .is-coproduct.[]∘ι₁ = Po.universal∘i₁
       coprod .is-coproduct.[]∘ι₂ = Po.universal∘i₂
       coprod .is-coproduct.unique p q = Po.unique p q
@@ -181,8 +182,8 @@ A coproduct is a pushout under a span whose apex is the initial object.
   with-pushouts bot po = fcc where
     module bot = Initial bot
     mkcoprod : ∀ A B → Coproduct C A B
-    mkcoprod A B = record { has-is-coproduct = initial-pushout→coproduct bot.has⊥ po' }
-      where po' = po (bot.has⊥ A .centre) (bot.has⊥ B .centre) .Pushout.has-is-po
+    mkcoprod A B = record { has-is-coproduct = initial-pushout→coproduct bot.has-is-init po' }
+      where po' = po (bot.¡) (bot.¡) .Pushout.has-is-po
 
     mkcoeq : ∀ {A B} (f g : Hom A B) → Coequaliser C f g
     mkcoeq {A = A} {B} f g = coequ where
@@ -272,9 +273,11 @@ limits]].
     : ∀ {P X Y I} {in1 : Hom X P} {in2 : Hom Y P} {f : Hom I X} {g : Hom I Y}
     → is-initial C I → is-coproduct C in1 in2 → is-pushout C f in1 g in2
   coproduct→initial-pushout i r = po where
+    module I = is-initial i
     open is-pushout
+
     po : is-pushout C _ _ _ _
-    po .square = is-contr→is-prop (i _) _ _
+    po .square = I.¡-unique₂ _ _
     po .universal _ = r .is-coproduct.[_,_] _ _
     po .universal∘i₁ = r .is-coproduct.[]∘ι₁
     po .universal∘i₂ = r .is-coproduct.[]∘ι₂
@@ -312,7 +315,7 @@ module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
       → is-coproduct C in1 in2
       → is-coproduct D (F.₁ in1) (F.₁ in2)
     pres-coproduct  init copr = initial-pushout→coproduct D (pres-⊥ init)
-      (pres-pushout {f = init _ .centre} {g = init _ .centre}
+      (pres-pushout {f = is-initial.¡ init} {g = is-initial.¡ init}
         (coproduct→initial-pushout C init copr))
     pres-epis : ∀ {A B} {f : C.Hom A B} → C.is-epic f → D.is-epic (F.₁ f)
     pres-epis {f = f} epi = is-pushout→is-epic

--- a/src/Cat/Diagram/Colimit/Initial.lagda.md
+++ b/src/Cat/Diagram/Colimit/Initial.lagda.md
@@ -22,7 +22,6 @@ module Cat.Diagram.Colimit.Initial {o h} (C : Precategory o h) where
 ```agda
 open Precategory C
 
-open Initial
 open Functor
 open _=>_
 ```
@@ -37,24 +36,30 @@ is-colimit→is-initial
   : ∀ {T : Ob} {eta : ¡F => Const T}
   → is-colimit {C = C} ¡F T eta
   → is-initial C T
-is-colimit→is-initial colim Y = contr (colim.universal (λ ()) (λ ()))
-                                      (λ _ → sym (colim.unique _ _ _ λ ()))
+{-# INLINE is-colimit→is-initial #-}
+is-colimit→is-initial colim = record
+  { ¡ = colim.universal (λ ()) (λ ())
+  ; ¡-unique = λ h → colim.unique (λ ()) (λ ()) h (λ ())
+  }
   where module colim = is-colimit colim
 
 is-initial→is-colimit : ∀ {T : Ob} {F : Functor ⊥Cat C} → is-initial C T → is-colimit {C = C} F T ¡nt
 is-initial→is-colimit {T} {F} init = to-is-colimitp mc λ {} where
+  open is-initial init
   open make-is-colimit
+
   mc : make-is-colimit F T
   mc .ψ ()
   mc .commutes ()
-  mc .universal _ _ = init _ .centre
+  mc .universal _ _ = ¡
   mc .factors {}
-  mc .unique _ _ _ _ = sym (init _ .paths _)
+  mc .unique _ _ _ _ = ¡-unique _
 
 Colimit→Initial : Colimit {C = C} ¡F → Initial C
-Colimit→Initial colim .bot = Colimit.coapex colim
-Colimit→Initial colim .has⊥ = is-colimit→is-initial (Colimit.has-colimit colim)
+{-# INLINE Colimit→Initial #-}
+Colimit→Initial colim .Initial.bot = Colimit.coapex colim
+Colimit→Initial colim .Initial.has-is-init = is-colimit→is-initial (Colimit.has-colimit colim)
 
 Initial→Colimit : ∀ {F : Functor ⊥Cat C} → Initial C → Colimit {C = C} F
-Initial→Colimit init = to-colimit (is-initial→is-colimit (init .has⊥))
+Initial→Colimit init = to-colimit (is-initial→is-colimit (init .Initial.has-is-init))
 ```

--- a/src/Cat/Diagram/Comonad/Writer.lagda.md
+++ b/src/Cat/Diagram/Comonad/Writer.lagda.md
@@ -128,13 +128,13 @@ products.
 
 ```agda
     mk .unit .is-natural x y f = ⟨⟩-unique₂ (pulll π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ idl f)
-      (pulll π₁∘⟨⟩ ∙ π₁∘⟨⟩ ∙ sym (pullr (sym (!-unique _))))
+      (pulll π₁∘⟨⟩ ∙ π₁∘⟨⟩ ∙ sym (pullr (!-unique _)))
       (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩ ∙ idr f)
     mk .mult .is-natural x y f = products! products
     mk .has-is-monad .μ-unitr =
       let
         lemma =
-          m.μ ∘ ⟨ π₁ , m.η ∘ ! ∘ π₂ ⟩               ≡˘⟨ ap₂ _∘_ refl (⟨⟩-unique (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ idl π₁) (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩ ∙ ap₂ _∘_ refl (!-unique _))) ⟩
+          m.μ ∘ ⟨ π₁ , m.η ∘ ! ∘ π₂ ⟩               ≡˘⟨ ap₂ _∘_ refl (⟨⟩-unique (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ idl π₁) (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩ ∙ ap₂ _∘_ refl (sym (!-unique _)))) ⟩
           m.μ ∘ ⟨ id ∘ π₁ , m.η ∘ π₂ ⟩ ∘ ⟨ π₁ , ! ⟩ ≡⟨ pulll m.μ-unitr ⟩
           π₁ ∘ ⟨ π₁ , ! ⟩                           ≡⟨ π₁∘⟨⟩ ⟩
           π₁                                        ∎

--- a/src/Cat/Diagram/Coproduct/Indexed.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Indexed.lagda.md
@@ -294,11 +294,13 @@ is-initial→is-disjoint-coproduct
   → is-initial C ∅
   → is-disjoint-coproduct F i
 is-initial→is-disjoint-coproduct {F = F} {i = i} init = is-disjoint where
+  open is-initial init
   open is-indexed-coproduct
+
   is-coprod : is-indexed-coproduct F i
-  is-coprod .match _ = init _ .centre
+  is-coprod .match _ = ¡
   is-coprod .commute {i = i} = absurd i
-  is-coprod .unique {h = h} f p i = init _ .paths h (~ i)
+  is-coprod .unique {h = h} f p = ¡-unique h
 
   open is-disjoint-coproduct
   is-disjoint : is-disjoint-coproduct F i

--- a/src/Cat/Diagram/Duals.lagda.md
+++ b/src/Cat/Diagram/Duals.lagda.md
@@ -182,23 +182,31 @@ $C\op$. We prove these correspondences here:
 
   Coterminal→Initial : Terminal (C ^op) → Initial C
   {-# INLINE Coterminal→Initial #-}
-  Coterminal→Initial term .bot = term .top
-  Coterminal→Initial term .has-is-init = is-coterminal→is-initial (term .has-is-term)
+  Coterminal→Initial term = record
+    { bot = term .top
+    ; has-is-init = is-coterminal→is-initial (term .has-is-term)
+    }
 
   Terminal→Coinitial : Terminal C → Initial (C ^op)
   {-# INLINE Terminal→Coinitial #-}
-  Terminal→Coinitial term .bot = term .top
-  Terminal→Coinitial term .has-is-init = is-terminal→is-coinitial (term .has-is-term)
+  Terminal→Coinitial term = record
+    { bot = term .top
+    ; has-is-init = is-terminal→is-coinitial (term .has-is-term)
+    }
 
   Initial→Coterminal : Initial C → Terminal (C ^op)
   {-# INLINE Initial→Coterminal #-}
-  Initial→Coterminal init .top = init .bot
-  Initial→Coterminal init .has-is-term = is-initial→is-coterminal (init .has-is-init)
+  Initial→Coterminal init = record
+    { top = init .bot
+    ; has-is-term = is-initial→is-coterminal (init .has-is-init)
+    }
 
   Coinitial→terminal : Initial (C ^op) → Terminal C
   {-# INLINE Coinitial→terminal #-}
-  Coinitial→terminal init .top = init .bot
-  Coinitial→terminal init .has-is-term = is-coinitial→is-terminal (init .has-is-init)
+  Coinitial→terminal init = record
+    { top = init .bot
+    ; has-is-term = is-coinitial→is-terminal (init .has-is-init)
+    }
 ```
 
 ## Pullback/pushout

--- a/src/Cat/Diagram/Duals.lagda.md
+++ b/src/Cat/Diagram/Duals.lagda.md
@@ -146,35 +146,38 @@ $C\op$. We prove these correspondences here:
 
   is-coterminal→is-initial
     : ∀ {A} → is-terminal (C ^op) A → is-initial C A
-  is-coterminal→is-initial x = x
+  is-coterminal→is-initial term = Equiv.to is-terminal-univ term
 
   is-terminal→is-coinitial
     : ∀ {A} → is-terminal C A → is-initial (C ^op) A
-  is-terminal→is-coinitial x = x
+  is-terminal→is-coinitial term = Equiv.to is-terminal-univ term
 
   is-initial→is-coterminal
     : ∀ {A} → is-initial C A → is-terminal (C ^op) A
-  is-initial→is-coterminal x = x
+  {-# INLINE is-initial→is-coterminal #-}
+  is-initial→is-coterminal = hom-contr→is-terminal
 
   is-coinitial→is-terminal
     : ∀ {A} → is-initial (C ^op) A → is-terminal C A
-  is-coinitial→is-terminal x = x
+  {-# INLINE is-coinitial→is-terminal #-}
+  is-coinitial→is-terminal = hom-contr→is-terminal
 
   Coterminal→Initial : Terminal (C ^op) → Initial C
   Coterminal→Initial term .bot = term .top
-  Coterminal→Initial term .has⊥ = is-coterminal→is-initial (term .has⊤)
+  Coterminal→Initial term .has⊥ = is-coterminal→is-initial (term .has-is-term)
 
   Terminal→Coinitial : Terminal C → Initial (C ^op)
   Terminal→Coinitial term .bot = term .top
-  Terminal→Coinitial term .has⊥ = is-terminal→is-coinitial (term .has⊤)
+  Terminal→Coinitial term .has⊥ = is-terminal→is-coinitial (term .has-is-term)
 
   Initial→Coterminal : Initial C → Terminal (C ^op)
   Initial→Coterminal init .top = init .bot
-  Initial→Coterminal init .has⊤ = is-initial→is-coterminal (init .has⊥)
+  Initial→Coterminal init .has-is-term = is-initial→is-coterminal (init .has⊥)
 
   Coinitial→terminal : Initial (C ^op) → Terminal C
+  {-# INLINE Coinitial→terminal #-}
   Coinitial→terminal init .top = init .bot
-  Coinitial→terminal init .has⊤ = is-coinitial→is-terminal (init .has⊥)
+  Coinitial→terminal init .has-is-term = is-coinitial→is-terminal (init .has⊥)
 ```
 
 ## Pullback/pushout

--- a/src/Cat/Diagram/Duals.lagda.md
+++ b/src/Cat/Diagram/Duals.lagda.md
@@ -146,38 +146,59 @@ $C\op$. We prove these correspondences here:
 
   is-coterminal→is-initial
     : ∀ {A} → is-terminal (C ^op) A → is-initial C A
-  is-coterminal→is-initial term = Equiv.to is-terminal-univ term
+  {-# INLINE is-coterminal→is-initial #-}
+  is-coterminal→is-initial term = record
+    { ¡ = term.!
+    ; ¡-unique = term.!-unique
+    }
+    where module term = is-terminal term
 
   is-terminal→is-coinitial
     : ∀ {A} → is-terminal C A → is-initial (C ^op) A
-  is-terminal→is-coinitial term = Equiv.to is-terminal-univ term
+  {-# INLINE is-terminal→is-coinitial #-}
+  is-terminal→is-coinitial term = record
+    { ¡ = term.!
+    ; ¡-unique = term.!-unique
+    }
+    where module term = is-terminal term
 
   is-initial→is-coterminal
     : ∀ {A} → is-initial C A → is-terminal (C ^op) A
   {-# INLINE is-initial→is-coterminal #-}
-  is-initial→is-coterminal = hom-contr→is-terminal
+  is-initial→is-coterminal init = record
+    { ! = init.¡
+    ; !-unique = init.¡-unique
+    }
+    where module init = is-initial init
 
   is-coinitial→is-terminal
     : ∀ {A} → is-initial (C ^op) A → is-terminal C A
   {-# INLINE is-coinitial→is-terminal #-}
-  is-coinitial→is-terminal = hom-contr→is-terminal
+  is-coinitial→is-terminal init = record
+    { ! = init.¡
+    ; !-unique = init.¡-unique
+    }
+    where module init = is-initial init
 
   Coterminal→Initial : Terminal (C ^op) → Initial C
+  {-# INLINE Coterminal→Initial #-}
   Coterminal→Initial term .bot = term .top
-  Coterminal→Initial term .has⊥ = is-coterminal→is-initial (term .has-is-term)
+  Coterminal→Initial term .has-is-init = is-coterminal→is-initial (term .has-is-term)
 
   Terminal→Coinitial : Terminal C → Initial (C ^op)
+  {-# INLINE Terminal→Coinitial #-}
   Terminal→Coinitial term .bot = term .top
-  Terminal→Coinitial term .has⊥ = is-terminal→is-coinitial (term .has-is-term)
+  Terminal→Coinitial term .has-is-init = is-terminal→is-coinitial (term .has-is-term)
 
   Initial→Coterminal : Initial C → Terminal (C ^op)
+  {-# INLINE Initial→Coterminal #-}
   Initial→Coterminal init .top = init .bot
-  Initial→Coterminal init .has-is-term = is-initial→is-coterminal (init .has⊥)
+  Initial→Coterminal init .has-is-term = is-initial→is-coterminal (init .has-is-init)
 
   Coinitial→terminal : Initial (C ^op) → Terminal C
   {-# INLINE Coinitial→terminal #-}
   Coinitial→terminal init .top = init .bot
-  Coinitial→terminal init .has-is-term = is-coinitial→is-terminal (init .has⊥)
+  Coinitial→terminal init .has-is-term = is-coinitial→is-terminal (init .has-is-init)
 ```
 
 ## Pullback/pushout

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -209,15 +209,11 @@ the code below demonstrates.
 
     im : Initial _
     im .bot = itself
-    im .has⊥ other = contr hom unique where
-      hom : ↓Hom _ _ itself other
-      hom .top = tt
-      hom .bot = other .map
-      hom .com = ext refl
-
-      unique : ∀ x → hom ≡ x
-      unique x = ↓Hom-path _ _ refl
-        (ext (intror refl ∙ ap map (x .com) ∙ elimr refl))
+    im .has-is-init .is-initial.¡ {o} .top = tt
+    im .has-is-init .is-initial.¡ {o} .bot = o .map
+    im .has-is-init .is-initial.¡ {o} .com = ext refl
+    im .has-is-init .is-initial.¡-unique {o} h =
+      ↓Hom-path _ _ refl (ext (intror refl ∙ ap map (sym (h .com)) ∙ elimr refl))
 ```
 
 Hence the characterisation of regular monomorphisms given in the

--- a/src/Cat/Diagram/Exponential.lagda.md
+++ b/src/Cat/Diagram/Exponential.lagda.md
@@ -420,7 +420,7 @@ omit it from the page.
     f .F₀ h = pb {B = top} (-^B .F₁ (h .map)) (ƛ π₂) .apex
     f .F₁ {x} {y} h = pb _ _ .universal (sym p) where abstract
       p : ƛ π₂ ∘ !  ≡ -^B .F₁ (y .map) ∘ -^B .F₁ (h .map) ∘ pb {B = top} (-^B .F₁ (x .map)) (ƛ π₂) .p₁
-      p = ƛ π₂ ∘ !                                         ≡⟨ ap (ƛ π₂ ∘_) (!-unique _) ⟩
+      p = ƛ π₂ ∘ !                                         ≡˘⟨ ap (ƛ π₂ ∘_) (!-unique _) ⟩
           ƛ π₂ ∘ pb _ _ .p₂                                ≡˘⟨ pb _ _ .square ⟩
           ƛ (x .map ∘ ev) ∘ pb _ _ .p₁                     ≡˘⟨ ap (-^B .F₁) (h .com) ⟩∘⟨refl ⟩
           ƛ ((y .map ∘ h .map) ∘ ev) ∘ pb _ _ .p₁          ≡⟨ pushl (-^B .F-∘ _ _) ⟩
@@ -430,11 +430,11 @@ omit it from the page.
 <!--
 ```agda
     f .F-id = sym $ pb _ _ .Pullback.unique
-      (sym (eliml (-^B .F-id) ∙ intror refl)) (sym (!-unique _))
+      (sym (eliml (-^B .F-id) ∙ intror refl)) (!-unique _)
 
     f .F-∘ f g = sym $ pb _ _ .Pullback.unique
       (pulll (pb _ _ .p₁∘universal) ∙∙ pullr (pb _ _ .p₁∘universal) ∙∙ pulll (sym (-^B .F-∘ _ _)))
-      (sym (!-unique _))
+      (!-unique _)
 
   exponentiable→constant-family⊣product
     : (pb : has-pullbacks C)
@@ -501,7 +501,7 @@ $\Delta_B \dashv \Pi_B$ we've been chasing.
         Hom X (Π.₀ f)
           ≃⟨ Pullback.pullback-univ (pb _ _) ⟩
         Σ (Hom X (-^B .F₀ (f .dom))) (λ h → Σ (Hom X top) λ h' → ƛ (f .map ∘ ev) ∘ h ≡ ƛ π₂ ∘ h')
-          ≃⟨ Σ-ap-snd (λ x → Σ-contr-fst (has⊤ X)) ⟩
+          ≃⟨ Σ-ap-snd (λ x → Σ-contr-fst (is-terminal→hom-contr has-is-term X)) ⟩
         Σ (Hom X (-^B .F₀ (f .dom))) (λ h → ƛ (f .map ∘ ev) ∘ h ≡ ƛ π₂ ∘ !)
           ≃⟨ Σ-ap (Equiv.inverse (ƛ , lambda-is-equiv _)) (coh₁ f) ⟩
         Σ (Hom (X ⊗₀ B) (f .dom)) (λ h → f .map ∘ h ≡ π₂)

--- a/src/Cat/Diagram/Image.lagda.md
+++ b/src/Cat/Diagram/Image.lagda.md
@@ -172,7 +172,7 @@ through $k$:
       : ∀ {c} (m : Hom c b) (M-m : M .fst m) (i : Hom a c)
       → m ∘ i ≡ f
       → Hom Im c
-    universal m M i p = im .has⊥ obj .centre .bot .map where
+    universal m M i p = im .¡ {obj} .bot .map where
       obj : ↓Obj _ _
       obj .dom = tt
       obj .cod = cut m , M
@@ -182,7 +182,7 @@ through $k$:
       : ∀ {c} {m : Hom c b} {M : M .fst m} {i : Hom a c}
       → {p : m ∘ i ≡ f}
       → m ∘ universal m M i p ≡ Im→codomain
-    universal-factors {m = m} {M} {i} {p} = im .has⊥ _ .centre .bot .com
+    universal-factors {m = m} {M} {i} {p} = im .¡ .bot .com
 
     universal-commutes
       : ∀ {c} {m : Hom c b} {M : M .fst m} {i : Hom a c}

--- a/src/Cat/Diagram/Initial.lagda.md
+++ b/src/Cat/Diagram/Initial.lagda.md
@@ -2,7 +2,7 @@
 ```agda
 open import Cat.Prelude
 
-import Cat.Morphism
+import Cat.Reasoning
 ```
 -->
 
@@ -13,7 +13,7 @@ module Cat.Diagram.Initial where
 <!--
 ```agda
 module _ {o h} (C : Precategory o h) where
-  open Cat.Morphism C
+  open Cat.Reasoning C
 ```
 -->
 
@@ -23,30 +23,89 @@ An object $\bot$ of a category $\mathcal{C}$ is said to be **initial**
 if there exists a _unique_ map to any other object:
 
 ```agda
-  is-initial : Ob → Type _
-  is-initial ob = ∀ x → is-contr (Hom ob x)
-
-  record Initial : Type (o ⊔ h) where
+  record is-initial (bot : Ob) : Type (o ⊔ h) where
+    no-eta-equality
     field
-      bot  : Ob
-      has⊥ : is-initial bot
-```
-
-We refer to the centre of contraction as `¡`{.Agda}. Since it inhabits a
-contractible type, it is unique.
-
-```agda
-    ¡ : ∀ {x} → Hom bot x
-    ¡ = has⊥ _ .centre
-
-    ¡-unique : ∀ {x} (h : Hom bot x) → ¡ ≡ h
-    ¡-unique = has⊥ _ .paths
+      ¡ : ∀ {x} → Hom bot x
+      ¡-unique : ∀ {x} (h : Hom bot x) → h ≡ ¡
 
     ¡-unique₂ : ∀ {x} (f g : Hom bot x) → f ≡ g
-    ¡-unique₂ = is-contr→is-prop (has⊥ _)
+    ¡-unique₂ f g = ¡-unique f ∙ sym (¡-unique g)
+
+  record Initial : Type (o ⊔ h) where
+    no-eta-equality
+    field
+      bot  : Ob
+      has-is-init : is-initial bot
+
+    open is-initial has-is-init public
+```
+
+<!--
+```agda
+  {-# INLINE is-initial.constructor #-}
+  {-# INLINE Initial.constructor #-}
+
+module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Reasoning C
+
+  is-initial-is-prop : ∀ {b} → is-prop (is-initial C b)
+  is-initial-is-prop b-init b-init' = path where
+    open is-initial
+
+    ¡-path : ∀ {x} → b-init .¡ {x} ≡ b-init' .¡ {x}
+    ¡-path = b-init' .¡-unique (b-init .¡)
+
+    path : b-init ≡ b-init'
+    path i .¡ = ¡-path i
+    path i .¡-unique h =
+      is-prop→pathp (λ i → Hom-set _ _ h (¡-path i))
+        (¡-unique b-init h)
+        (¡-unique b-init' h) i
+
+  instance
+    H-Level-is-initial : ∀ {n} {b} → H-Level (is-initial C b) (suc n)
+    H-Level-is-initial = prop-instance is-initial-is-prop
+
+  private unquoteDecl initial-Σ-iso = declare-record-iso initial-Σ-iso (quote Initial)
+
+  Initial≃is-initial
+    : Initial C ≃ (Σ[ coapex ∈ Ob ] is-initial C coapex)
+  Initial≃is-initial = Iso→Equiv initial-Σ-iso
+
+  instance
+    Extensional-Initial
+      : ∀ {ℓr}
+      → ⦃ sa : Extensional Ob ℓr ⦄
+      → Extensional (Initial C) ℓr
+    Extensional-Initial ⦃ sa ⦄ =
+      embedding→extensional
+        (Equiv→Embedding Initial≃is-initial ∙emb (fst , Subset-proj-embedding λ _ → hlevel 1))
+        sa
+
+  -- Flattened record to make constructing terminal objects using
+  -- 'record where' and 'record { Module }' easier.
+  record make-initial : Type (o ⊔ ℓ) where
+    field
+      bot : Ob
+      ¡ : ∀ {x} → Hom bot x
+      ¡-unique : ∀ {x} (h : Hom bot x) → h ≡ ¡
+
+  to-initial : make-initial → Initial C
+  {-# INLINE to-initial #-}
+  to-initial mk = record
+    { bot = bot
+    ; has-is-init = record
+      { ¡ = ¡
+      ; ¡-unique = ¡-unique
+      }
+    }
+    where open make-initial mk
+
 
   open Initial
 ```
+-->
 
 ## Intuition
 
@@ -68,13 +127,38 @@ like a notion of **Syntax** for our category.  The idea here is that we
 have a _unique_ means of interpreting our syntax into any other object,
 which is exhibited by the universal map `¡`{.Agda}
 
+## Universal property
+
+An object $b : \cC$ is initial if and only if the type of morphisms
+$\cC(b, x)$ is [[contractible]] for every $x : \cC$.
+
+```agda
+  hom-contr→is-initial
+    : ∀ {b}
+    → (∀ x → is-contr (Hom b x))
+    → is-initial C b
+  {-# INLINE hom-contr→is-initial #-}
+  hom-contr→is-initial hom-contr = record
+    { ¡ = λ {x} → hom-contr x .centre
+    ; ¡-unique = λ {x} h → sym (hom-contr x .paths h)
+    }
+
+  is-initial→hom-contr
+    : ∀ {b}
+    → is-initial C b
+    → ∀ x → is-contr (Hom b x)
+  is-initial→hom-contr b-init x = contr b.¡ λ h → sym (b.¡-unique h)
+    where module b = is-initial b-init
+```
+
+
 ## Uniqueness
 
 One important fact about initial objects is that they are **unique** up
 to isomorphism:
 
 ```agda
-  ⊥-unique : (i i' : Initial) → bot i ≅ bot i'
+  ⊥-unique : (i i' : Initial C) → bot i ≅ bot i'
   ⊥-unique i i' = make-iso (¡ i) (¡ i') (¡-unique₂ i' _ _) (¡-unique₂ i _ _)
 ```
 
@@ -82,31 +166,6 @@ Additionally, if $C$ is a category, then the space of initial objects is
 a proposition:
 
 ```agda
-  ⊥-is-prop : is-category C → is-prop Initial
-  ⊥-is-prop ccat x1 x2 i .bot =
-    Univalent.iso→path ccat (⊥-unique x1 x2) i
-
-  ⊥-is-prop ccat x1 x2 i .has⊥ ob =
-    is-prop→pathp
-      (λ i → is-contr-is-prop
-        {A = Hom (Univalent.iso→path ccat (⊥-unique x1 x2) i) _})
-      (x1 .has⊥ ob) (x2 .has⊥ ob) i
+  ⊥-is-prop : is-category C → is-prop (Initial C)
+  ⊥-is-prop ccat x1 x2 = ext (Univalent.iso→path ccat (⊥-unique x1 x2))
 ```
-
-<!--
-```agda
-module _ {o h} {C : Precategory o h} where
-  open Cat.Morphism C
-  private unquoteDecl eqv = declare-record-iso eqv (quote Initial)
-
-  instance
-    Extensional-Initial
-      : ∀ {ℓr}
-      → ⦃ sa : Extensional Ob ℓr ⦄
-      → Extensional (Initial C) ℓr
-    Extensional-Initial ⦃ sa ⦄ =
-      embedding→extensional
-        (Iso→Embedding eqv ∙emb (fst , Subset-proj-embedding λ _ → hlevel 1))
-        sa
-```
--->

--- a/src/Cat/Diagram/Initial/Weak.lagda.md
+++ b/src/Cat/Diagram/Initial/Weak.lagda.md
@@ -76,7 +76,8 @@ the joint equaliser $i : L \to X$ of all arrows $X \to X$ is an initial object.
     → is-joint-equaliser C {I = Hom X X} (λ x → x) l
     → has-equalisers C
     → is-initial C L
-  is-weak-initial→equaliser X {L} {i} is-wi lim eqs y = contr cen (p' _) where
+  {-# INLINE is-weak-initial→equaliser #-}
+  is-weak-initial→equaliser X {L} {i} is-wi lim eqs = L-initial where
     open is-joint-equaliser lim
 ```
 
@@ -86,7 +87,7 @@ arrows $f, g : L \to Y$, consider their equaliser $j : E \to L$. First,
 we have some arrow $k : X \to E$.
 
 ```agda
-    p' : is-prop (Hom L y)
+    p' : ∀ {y} → is-prop (Hom L y)
     p' f g = ∥-∥-out! do
       let
         module fg = Equaliser (eqs f g)
@@ -124,8 +125,12 @@ since $j$ equalises $f$ and $g$ by construction, we have $f = g$!
 
       pure (s f g fg.equal)
 
-    cen : Hom L y
-    cen = ∥-∥-out p' ((_∘ i) <$> is-wi y)
+    cen : ∀ {y} → Hom L y
+    cen {y} = ∥-∥-out p' ((_∘ i) <$> is-wi y)
+
+    L-initial : is-initial C L
+    {-# INLINE L-initial #-}
+    L-initial = hom-contr→is-initial λ y → is-prop∙→is-contr p' cen
 ```
 
 Putting this together, we can show that, if a [[complete category]] has
@@ -138,7 +143,7 @@ a small weakly initial family, then it has an initial object.
     → is-weak-initial-fam F
     → Initial C
   is-complete-weak-initial→initial {κ = κ} {I} F compl wif =
-    record { has⊥ = equal-is-initial } where
+    record { has-is-init = equal-is-initial } where
 ```
 
 <details>

--- a/src/Cat/Diagram/Limit/Cone.lagda.md
+++ b/src/Cat/Diagram/Limit/Cone.lagda.md
@@ -190,6 +190,7 @@ differently.
     → is-terminal Cones K
     → is-limit F (Cone.apex K) (Cone→cone K)
   is-terminal-cone→is-limit {K = K} term = isl where
+    open is-terminal term
     open Cone-hom
     open is-ran
     open Cone
@@ -202,10 +203,10 @@ differently.
       α' .commutes f = sym (α .is-natural _ _ f) ∙ C.elimr (M .Functor.F-id)
 
       nt : M => !Const (K .apex)
-      nt .η x = term α' .centre .map
+      nt .η x = ! {α'} .map
       nt .is-natural tt tt tt = C.elimr (M .Functor.F-id) ∙ C.introl refl
-    isl .σ-comm = ext λ x → term _ .centre .com _
-    isl .σ-uniq {σ' = σ'} x = ext λ _ → ap map $ term _ .paths λ where
+    isl .σ-comm = ext λ x → ! .com x
+    isl .σ-uniq {σ' = σ'} x = ext λ _ → ap map $ sym $ !-unique λ where
       .map   → σ' .η _
       .com _ → sym (x ηₚ _)
 ```
@@ -218,16 +219,18 @@ unpacking data.
     : ∀ {x} {eps : Const x => F}
     → (L : is-limit F x eps)
     → is-terminal Cones (record { commutes = is-limit.commutes L })
-  is-limit→is-terminal-cone {x = x} L K = term where
+  {-# INLINE is-limit→is-terminal-cone #-}
+  is-limit→is-terminal-cone {x = x} L = term where
     module L = is-limit L
-    module K = Cone K
     open Cone-hom
+    open Cone
 
-    term : is-contr (Cone-hom K _)
-    term .centre .map   = L.universal K.ψ K.commutes
-    term .centre .com _ = L.factors K.ψ K.commutes
-    term .paths f =
-      Cone-hom-path (sym (L.unique K.ψ K.commutes (f .map) (f .com)))
+    term : is-terminal Cones (record { commutes = is-limit.commutes L })
+    {-# INLINE term #-}
+    term = record
+      { ! = λ {K} → cone-hom (L.universal (K .ψ) (K .commutes)) (λ _ → L.factors _ _)
+      ; !-unique = λ {K} h → Cone-hom-path (L.unique (K .ψ) (K .commutes) (h .map) (h .com))
+      }
 ```
 
 <!--
@@ -237,11 +240,11 @@ unpacking data.
   Terminal-cone→Limit : Terminal Cones → Limit F
   Terminal-cone→Limit x .Ext     = _
   Terminal-cone→Limit x .eps     = _
-  Terminal-cone→Limit x .has-ran = is-terminal-cone→is-limit (x .Terminal.has⊤)
+  Terminal-cone→Limit x .has-ran = is-terminal-cone→is-limit (x .Terminal.has-is-term)
 
   Limit→Terminal-cone : Limit F → Terminal Cones
   Limit→Terminal-cone x .Terminal.top  = _
-  Limit→Terminal-cone x .Terminal.has⊤ = is-limit→is-terminal-cone
+  Limit→Terminal-cone x .Terminal.has-is-term = is-limit→is-terminal-cone
     (Limit.has-limit x)
 ```
 -->

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import Cat.Diagram.Pullback.Properties
 open import Cat.Instances.Shape.Parallel
+open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Limit.Equaliser
 open import Cat.Diagram.Limit.Pullback
 open import Cat.Diagram.Limit.Terminal
@@ -106,10 +107,10 @@ products).
     : is-finitely-complete → Finitely-complete
   is-finitely-complete→Finitely-complete flim = Flim where
     Flim : Finitely-complete
-    Flim .terminal = Limit→Terminal C (flim finite-cat _)
+    Flim .terminal = Limit→Terminal C ¡F (flim finite-cat _)
     Flim .products a b = Limit→Product C (flim Disc-finite _)
     Flim .equalisers f g = Limit→Equaliser C (flim ·⇉·-finite _)
-    Flim .pullbacks f g = Limit→Pullback C {lzero} {lzero} (flim ·→·←·-finite _)
+    Flim .pullbacks f g = Limit→Pullback C (cospan→cospan-diagram lzero lzero f g) (flim ·→·←·-finite _)
 ```
 
 ## With equalisers
@@ -275,7 +276,7 @@ object $*$.
 
     prod : is-product C p1 p2
     prod .is-product.⟨_,_⟩ p1' p2' =
-      Pb.universal {p₁' = p1'} {p₂' = p2'} (is-contr→is-prop (term _) _ _)
+      Pb.universal (is-terminal.!-unique₂ term (f ∘ p1') (g ∘ p2'))
     prod .is-product.π₁∘⟨⟩ = Pb.p₁∘universal
     prod .is-product.π₂∘⟨⟩ = Pb.p₂∘universal
     prod .is-product.unique p q = Pb.unique p q
@@ -287,8 +288,8 @@ object $*$.
   with-pullbacks top pb = fc where
     module top = Terminal top
     mkprod : ∀ A B → Product C A B
-    mkprod A B = record { has-is-product = terminal-pullback→product top.has⊤ pb' }
-      where pb' = pb (top.has⊤ A .centre) (top.has⊤ B .centre) .Pullback.has-is-pb
+    mkprod A B = record { has-is-product = terminal-pullback→product top.has-is-term pb' }
+      where pb' = pb (top.!) (top.!) .Pullback.has-is-pb
 
     mkeq : ∀ {A B} (f g : Hom A B) → Equaliser C f g
     mkeq {A = A} {B} f g = eq where
@@ -427,9 +428,10 @@ Putting it all together into a record we get our proof of finite completeness:
     : ∀ {P X Y T} {p1 : Hom P X} {p2 : Hom P Y} {f : Hom X T} {g : Hom Y T}
     → is-terminal C T → is-product C p1 p2 → is-pullback C p1 f p2 g
   product→terminal-pullback t r = pb where
+    open is-terminal t
     open is-pullback
     pb : is-pullback C _ _ _ _
-    pb .square = is-contr→is-prop (t _) _ _
+    pb .square = !-unique₂ _ _
     pb .universal _ = r .is-product.⟨_,_⟩ _ _
     pb .p₁∘universal = r .is-product.π₁∘⟨⟩
     pb .p₂∘universal = r .is-product.π₂∘⟨⟩
@@ -440,29 +442,10 @@ Putting it all together into a record we get our proof of finite completeness:
   is-complete→finitely {a} {b} compl = with-pullbacks term' pb
     where
       pb : ∀ {x y z} (f : Hom x z) (g : Hom y z) → Pullback C f g
-      pb f g = Limit→Pullback C (compl (cospan→cospan-diagram _ _ f g))
-
-      idx : Precategory a b
-      idx = Lift-cat a b (Disc ⊥ λ x → absurd x)
-
-      F : Functor idx C
-      F .Functor.F₀ ()
-      F .Functor.F₁ {()}
-      F .Functor.F-id {()}
-      F .Functor.F-∘ {()}
-
-      limF : Limit F
-      limF = compl F
-      open Terminal
-      open Cone-hom
-      open Cone
+      pb f g = Limit→Pullback C _ (compl (cospan→cospan-diagram _ _ f g))
 
       term' : Terminal C
-      term' = record { top = Limit.apex limF ; has⊤ = limiting } where
-        limiting : ∀ x → is-contr _
-        limiting x =
-          contr (Limit.universal limF (λ { () }) (λ { {()} })) λ h →
-            sym (Limit.unique limF _ _ h λ { () })
+      term' = Limit→Terminal C ¡F (is-complete-lower a b lzero lzero compl ¡F)
 ```
 -->
 
@@ -507,8 +490,9 @@ products.
       → is-product C p1 p2
       → is-product D (F.₁ p1) (F.₁ p2)
     pres-product term pr = terminal-pullback→product D (pres-⊤ term)
-      (pres-pullback {f = term _ .centre} {g = term _ .centre}
+      (pres-pullback {f = !} {g = !}
         (product→terminal-pullback C term pr))
+      where open is-terminal term
 ```
 
 Since $f : A \to B$ being a monomorphism is equivalent to certain squares

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -2,8 +2,8 @@
 ```agda
 open import Cat.Diagram.Pullback.Properties
 open import Cat.Instances.Shape.Parallel
-open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Limit.Equaliser
+open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Limit.Pullback
 open import Cat.Diagram.Limit.Terminal
 open import Cat.Diagram.Product.Finite

--- a/src/Cat/Diagram/Limit/Initial.lagda.md
+++ b/src/Cat/Diagram/Limit/Initial.lagda.md
@@ -43,9 +43,8 @@ module _ {o ℓ} {C : Precategory o ℓ} (L : Limit (Id {C = C})) where
 
   Id-limit→Initial : Initial C
   Id-limit→Initial .bot = L.apex
-  Id-limit→Initial .has⊥ x = λ where
-    .centre → L.ψ x
-    .paths h → sym (intror rem₁ ∙ L.commutes h)
+  Id-limit→Initial .has-is-init .is-initial.¡ {x} = L.ψ x
+  Id-limit→Initial .has-is-init .is-initial.¡-unique h = intror rem₁ ∙ L.commutes h
 ```
 
 <!--

--- a/src/Cat/Diagram/Limit/Pullback.lagda.md
+++ b/src/Cat/Diagram/Limit/Pullback.lagda.md
@@ -10,7 +10,7 @@ open import Cat.Prelude
 -->
 
 ```agda
-module Cat.Diagram.Limit.Pullback {o h} (Cat : Precategory o h) where
+module Cat.Diagram.Limit.Pullback {oc ℓc} (C : Precategory oc ℓc) where
 ```
 
 We establish the correspondence between `Pullback`{.Agda} and the
@@ -18,11 +18,10 @@ We establish the correspondence between `Pullback`{.Agda} and the
 
 <!--
 ```agda
-open import Cat.Reasoning Cat
+open import Cat.Reasoning C
 
 -- Yikes:
 open is-pullback
-open Terminal
 open Cone-hom
 open Pullback
 open Functor
@@ -32,7 +31,7 @@ open Cone
 
 ```agda
 Square→Cone
-  : ∀ {x y} {P} {F : Functor (·→·←· {x} {y}) Cat}
+  : ∀ {x y} {P} {F : Functor (·→·←· {x} {y}) C}
   → (p1 : Hom P (F .F₀ cs-a)) (p2 : Hom P (F .F₀ cs-b))
   → F .F₁ {cs-a} {cs-c} _ ∘ p1 ≡ F .F₁ {cs-b} {cs-c} _ ∘ p2
   → Cone F
@@ -46,56 +45,78 @@ Square→Cone {F = F} p1 p2 square .commutes {cs-b} {cs-b} _ = eliml (F .F-id)
 Square→Cone {F = F} p1 p2 square .commutes {cs-b} {cs-c} _ = sym square
 Square→Cone {F = F} p1 p2 square .commutes {cs-c} {cs-c} _ = eliml (F .F-id)
 
-Pullback→Terminal-cone
-  : ∀ {x y} {A B C} {f : Hom A C} {g : Hom B C}
-  → Pullback Cat f g
-  → Terminal (Cones (cospan→cospan-diagram x y {C = Cat} f g))
-Pullback→Terminal-cone {f = f} {g} pb = lim where
-  module pb = Pullback pb
-  lim : Terminal (Cones _)
-  lim .top = Square→Cone _ _ pb.square
-  lim .has⊤ cone .centre .map      = pb.universal (cone .commutes (lift tt) ∙ sym (cone .commutes {cs-b} {cs-c} (lift tt)))
-  lim .has⊤ cone .centre .com cs-a = pb.p₁∘universal
-  lim .has⊤ cone .centre .com cs-b = pb.p₂∘universal
-  lim .has⊤ cone .centre .com cs-c = pullr pb.p₁∘universal ∙ cone .commutes (lift tt)
-  lim .has⊤ cone .paths otherhom = Cone-hom-path _ (sym (pb.unique (otherhom .com _) (otherhom .com _)))
+module _
+  {oj ℓj}
+  (Dia : Functor (·→·←· {oj} {ℓj}) C)
+  where
 
-Terminal-cone→Pullback
-  : ∀ {x y}
-  → {F : Functor (·→·←· {x} {y}) Cat}
-  → Terminal (Cones F)
-  → Pullback Cat (F .F₁ {cs-a} {cs-c} _) (F .F₁ {cs-b} {cs-c} _)
-Terminal-cone→Pullback {F = F} lim = pb where
-  module lim = Terminal lim
-  pb : Pullback Cat _ _
-  pb .apex = lim.top .apex
-  pb .p₁ = lim.top .ψ cs-a
-  pb .p₂ = lim.top .ψ cs-b
-  pb .has-is-pb .square = lim.top .commutes _ ∙ sym (lim.top .commutes {cs-b} {cs-c} _)
-  pb .has-is-pb .universal x = lim.has⊤ (Square→Cone _ _ x) .centre .map
-  pb .has-is-pb .p₁∘universal {p = p} = lim.has⊤ (Square→Cone _ _ p) .centre .com cs-a
-  pb .has-is-pb .p₂∘universal {p = p} = lim.has⊤ (Square→Cone _ _ p) .centre .com cs-b
-  pb .has-is-pb .unique {p₁' = p₁'} {p₂'} {p} {lim'} a b =
-    sym (ap map (lim.has⊤ (Square→Cone _ _ p) .paths other))
-    where
-      other : Cone-hom _ _ _
-      other .map = _
-      other .com cs-a = a
-      other .com cs-b = b
-      other .com cs-c =
-        lim.top .ψ cs-c ∘ lim'                         ≡˘⟨ pulll (lim.top .commutes _) ⟩
-        F .F₁ {cs-a} {cs-c} _ ∘ lim.top .ψ cs-a ∘ lim' ≡⟨ ap (_ ∘_) a ⟩
-        F .F₁ {cs-a} {cs-c} _ ∘ p₁'                    ∎
+  private
+    module Dia = Functor Dia
 
-Limit→Pullback
-  : ∀ {x y} {a b c} → {f : Hom a c} {g : Hom b c}
-  → Limit (cospan→cospan-diagram x y f g)
-  → Pullback Cat f g
-Limit→Pullback x = Terminal-cone→Pullback (Limit→Terminal-cone _ x)
+    a b c : Ob
+    a = Dia.₀ cs-a
+    b = Dia.₀ cs-b
+    c = Dia.₀ cs-c
 
-Pullback→Limit
-  : ∀ {x y} {A B C} {f : Hom A C} {g : Hom B C}
-  → Pullback Cat f g
-  → Limit (cospan→cospan-diagram x y {C = Cat} f g)
-Pullback→Limit x = Terminal-cone→Limit _ (Pullback→Terminal-cone x)
+    f : Hom a c
+    f = Dia.₁ (lift tt)
+
+    g : Hom b c
+    g = Dia.₁ (lift tt)
+
+  Pullback→Terminal-cone
+    : Pullback C f g
+    → Terminal (Cones Dia)
+  {-# INLINE Pullback→Terminal-cone #-}
+  Pullback→Terminal-cone pb = to-terminal (record { Pullback→Terminal-cone }) where
+    module Pullback→Terminal-cone where
+      module pb = Pullback pb
+
+      top : Cone Dia
+      top = Square→Cone pb.p₁ pb.p₂ pb.square
+
+      ! : ∀ {K : Cone Dia} → Cone-hom Dia K top
+      ! {K} .map = pb.universal (K .commutes (lift tt) ∙ sym (K .commutes {cs-b} {cs-c} (lift tt)))
+      ! {K} .com cs-a = pb.p₁∘universal
+      ! {K} .com cs-b = pb.p₂∘universal
+      ! {K} .com cs-c = pullr pb.p₁∘universal ∙ K .commutes (lift tt)
+
+      !-unique : ∀ {K} (h : Cone-hom Dia K top) → h ≡ !
+      !-unique h = Cone-hom-path Dia (pb.unique (h .com cs-a) (h .com cs-b))
+
+
+  Terminal-cone→Pullback
+    : Terminal (Cones Dia)
+    → Pullback C f g
+  Terminal-cone→Pullback lim = pb where
+    module lim = Terminal lim
+    pb : Pullback C _ _
+    pb .apex = lim.top .apex
+    pb .p₁ = lim.top .ψ cs-a
+    pb .p₂ = lim.top .ψ cs-b
+    pb .has-is-pb .square = lim.top .commutes _ ∙ sym (lim.top .commutes {cs-b} {cs-c} _)
+    pb .has-is-pb .universal x = lim.! {Square→Cone _ _ x} .map
+    pb .has-is-pb .p₁∘universal {p = p} = lim.! .com cs-a
+    pb .has-is-pb .p₂∘universal {p = p} = lim.! .com cs-b
+    pb .has-is-pb .unique {p₁' = p₁'} {p₂'} {p} {lim'} a b =
+      ap map (lim.!-unique other)
+      where
+        other : Cone-hom _ _ _
+        other .map = _
+        other .com cs-a = a
+        other .com cs-b = b
+        other .com cs-c =
+          lim.top .ψ cs-c ∘ lim'                         ≡˘⟨ pulll (lim.top .commutes _) ⟩
+          Dia.₁ {cs-a} {cs-c} _ ∘ lim.top .ψ cs-a ∘ lim' ≡⟨ ap (_ ∘_) a ⟩
+          Dia.₁ {cs-a} {cs-c} _ ∘ p₁'                    ∎
+
+  Limit→Pullback
+    : Limit Dia
+    → Pullback C f g
+  Limit→Pullback x = Terminal-cone→Pullback (Limit→Terminal-cone _ x)
+
+  Pullback→Limit
+    : Pullback C f g
+    → Limit Dia
+  Pullback→Limit x = Terminal-cone→Limit _ (Pullback→Terminal-cone x)
 ```

--- a/src/Cat/Diagram/Limit/Terminal.lagda.md
+++ b/src/Cat/Diagram/Limit/Terminal.lagda.md
@@ -23,7 +23,6 @@ module Cat.Diagram.Limit.Terminal {o h} (C : Precategory o h) where
 ```agda
 open Precategory C
 
-open Terminal
 open Functor
 open _=>_
 ```
@@ -34,28 +33,40 @@ open _=>_
 A [[terminal object]] is equivalently defined as a limit of the empty diagram.
 
 ```agda
-is-limit→is-terminal
-  : ∀ {T : Ob} {eps : Const T => ¡F}
-  → is-limit {C = C} ¡F T eps
-  → is-terminal C T
-is-limit→is-terminal lim Y = contr (lim.universal (λ ()) (λ ()))
-                                   (λ _ → sym (lim.unique _ _ _ λ ()))
-  where module lim = is-limit lim
 
-is-terminal→is-limit : ∀ {T : Ob} {F : Functor ⊥Cat C} → is-terminal C T → is-limit {C = C} F T ¡nt
-is-terminal→is-limit {T} {F} term = to-is-limitp ml λ {} where
-  open make-is-limit
-  ml : make-is-limit F T
-  ml .ψ ()
-  ml .commutes ()
-  ml .universal _ _ = term _ .centre
-  ml .factors {}
-  ml .unique _ _ _ _ = sym (term _ .paths _)
+module _ (Dia : Functor ⊥Cat C) where
 
-Limit→Terminal : Limit {C = C} ¡F → Terminal C
-Limit→Terminal lim .top = Limit.apex lim
-Limit→Terminal lim .has⊤ = is-limit→is-terminal (Limit.has-limit lim)
+  is-limit→is-terminal
+    : ∀ {T : Ob} {eps : Const T => Dia}
+    → is-limit {C = C} Dia T eps
+    → is-terminal C T
+  {-# INLINE is-limit→is-terminal #-}
+  is-limit→is-terminal lim = record
+    { ! = lim.universal (λ ()) (λ ())
+    ; !-unique = λ h → lim.unique (λ ()) (λ ()) h (λ ())
+    }
+    where module lim = is-limit lim
 
-Terminal→Limit : ∀ {F : Functor ⊥Cat C} → Terminal C → Limit {C = C} F
-Terminal→Limit term = to-limit (is-terminal→is-limit (term .has⊤))
+  is-terminal→is-limit : ∀ {T : Ob} {F : Functor ⊥Cat C} → is-terminal C T → is-limit {C = C} F T ¡nt
+  is-terminal→is-limit {T} {F} term = to-is-limitp ml λ {} where
+    open is-terminal term
+    open make-is-limit
+
+    ml : make-is-limit F T
+    ml .ψ ()
+    ml .commutes ()
+    ml .universal _ _ = !
+    ml .factors {}
+    ml .unique _ _ _ _ = !-unique _
+
+  Limit→Terminal
+    : Limit Dia → Terminal C
+  {-# INLINE Limit→Terminal #-}
+  Limit→Terminal lim = record
+    { top = Limit.apex lim
+    ; has-is-term = is-limit→is-terminal (Limit.has-limit lim)
+    }
+
+  Terminal→Limit : Terminal C → Limit Dia
+  Terminal→Limit term = to-limit (is-terminal→is-limit (Terminal.has-is-term term))
 ```

--- a/src/Cat/Diagram/Monad/Kleisli.lagda.md
+++ b/src/Cat/Diagram/Monad/Kleisli.lagda.md
@@ -175,9 +175,9 @@ Kleisli-not-univalent {κ} =
     T : Monad-on _
     T =
       Adjunction→Monad $
-      is-terminal→inclusion-is-right-adjoint (Sets κ)
+      is-terminal→inclusion-is-right-adjoint
         (el! (Lift _ ⊤))
-        (λ _ → hlevel 0)
+        (hom-contr→is-terminal λ _ → hlevel 0)
 
     open Cat.Reasoning (Kleisli-maps T)
 

--- a/src/Cat/Diagram/Omega.lagda.md
+++ b/src/Cat/Diagram/Omega.lagda.md
@@ -367,15 +367,16 @@ module props {o ℓ} {C : Precategory o ℓ} (pb : has-pullbacks C) (so : Subobj
       true .map ∘ classifies ⊤ₘ .top ∎
 
   true-domain-is-terminal : is-terminal C (true .dom)
-  true-domain-is-terminal X .centre  = classifies ⊤ₘ .top
-  true-domain-is-terminal X .paths h = true .monic _ _ (sym (is-total→factors record
-    { inv      = pb _ _ .universal (pullr refl)
-    ; inverses = record
-      { invl = pb _ _ .p₁∘universal
-      ; invr = Pullback.unique₂ (pb _ _) {p = pullr refl}
-        (pulll (pb _ _ .p₁∘universal)) (extendl (pb _ _ .p₂∘universal)) id-comm
-        (true .monic _ _ (extendl (sym (pb _ _ .square)) ∙ pullr (ap (h ∘_) id-comm)))
-      }
-    } .snd))
+  true-domain-is-terminal .is-terminal.! = classifies ⊤ₘ .top
+  true-domain-is-terminal .is-terminal.!-unique h =
+    true .monic h (classifies ⊤ₘ .top)
+    $ snd $ is-total→factors
+    $ make-invertible (pb _ _ .universal (pullr refl))
+      (pb _ _ .p₁∘universal)
+      (Pullback.unique₂ (pb _ _) {p = pullr refl}
+        (pulll (pb _ _ .p₁∘universal))
+        (extendl (pb _ _ .p₂∘universal))
+        id-comm
+        (true .monic _ _ (extendl (sym (pb _ _ .square)) ∙ pullr (ap (h ∘_) id-comm))))
 ```
 -->

--- a/src/Cat/Diagram/Product/Finite.lagda.md
+++ b/src/Cat/Diagram/Product/Finite.lagda.md
@@ -83,7 +83,7 @@ Cartesian→standard-finite-products F = prod where
     : ∀ {Y} {n} (F : Fin n → Ob) (f : (i : Fin n) → Hom Y (F i))
     → {h : Hom Y (F-apex F)} → ((i : Fin n) → F-pi F i ∘ h ≡ f i)
     → h ≡ F-mult F f
-  F-unique {n = zero} F f {h} p = sym $ !-unique terminal _
+  F-unique {n = zero} F f {h} p = !-unique terminal _
   F-unique {n = suc zero} F f {h} p = sym (idl h) ∙ p fzero
   F-unique {n = suc (suc n)} F f {h} p =
     products _ _ .unique (p fzero)

--- a/src/Cat/Diagram/Subterminal.lagda.md
+++ b/src/Cat/Diagram/Subterminal.lagda.md
@@ -38,7 +38,7 @@ In particular, every terminal object is subterminal.
 
 ```agda
   terminal→subterminal : ∀ {T} → is-terminal C T → is-subterminal T
-  terminal→subterminal term X = is-contr→is-prop (term X)
+  terminal→subterminal term X = is-terminal.!-unique₂ term
 ```
 
 Subterminal objects can be thought of as the interpretations of *truth

--- a/src/Cat/Diagram/Terminal.lagda.md
+++ b/src/Cat/Diagram/Terminal.lagda.md
@@ -150,12 +150,14 @@ We can further strengthen this implication to an if-and-only-if.
 <details>
 <summary>This holds essentially by definition, so we elide the details.
 </summary>
+
 ```agda
   is-terminal→hom-contr term x = contr t.! λ h → sym (t.!-unique h) where
     module t = is-terminal term
 
   is-terminal-univ {t = t} = prop-ext! is-terminal→hom-contr hom-contr→is-terminal
 ```
+
 </details>
 
 We can also state this universal property in terms of [[equivalences]]:

--- a/src/Cat/Diagram/Terminal.lagda.md
+++ b/src/Cat/Diagram/Terminal.lagda.md
@@ -26,29 +26,142 @@ An object $\top$ of a category $\mathcal{C}$ is said to be **terminal**
 if it admits a _unique_ map from any other object:
 
 ```agda
-  is-terminal : Ob → Type _
-  is-terminal ob = ∀ x → is-contr (Hom x ob)
+  record is-terminal (t : Ob) : Type (o ⊔ h) where
+    no-eta-equality
+    field
+      ! : ∀ {x} → Hom x t
+      !-unique : ∀ {x} (h : Hom x t) → h ≡ !
+
+    !-unique₂ : ∀ {x} (f g : Hom x t) → f ≡ g
+    !-unique₂ f g = !-unique f ∙ sym (!-unique g)
 
   record Terminal : Type (o ⊔ h) where
+    no-eta-equality
     field
       top : Ob
-      has⊤ : is-terminal top
+      has-is-term : is-terminal top
+
+    open is-terminal has-is-term public
 ```
 
-We refer to the centre of contraction as `!`{.Agda}. Since it inhabits a
-contractible type, it is unique.
+<!--
+```agda
+  {-# INLINE is-terminal.constructor #-}
+  {-# INLINE Terminal.constructor #-}
+
+
+module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Reasoning C
+
+  is-terminal-is-prop : ∀ {t} → is-prop (is-terminal C t)
+  is-terminal-is-prop {t} t-term t-term' = path where
+    open is-terminal
+
+    !-path : ∀ {x} → t-term .! {x} ≡ t-term' .! {x}
+    !-path = t-term' .!-unique (t-term .!)
+
+    path : t-term ≡ t-term'
+    path i .! = !-path i
+    path i .!-unique h =
+      is-prop→pathp (λ i → Hom-set _ _ h (!-path i))
+        (t-term .!-unique h)
+        (t-term' .!-unique h) i
+
+  instance
+    H-Level-is-terminal : ∀ {n} {t} → H-Level (is-terminal C t) (suc n)
+    H-Level-is-terminal = prop-instance is-terminal-is-prop
+
+  private unquoteDecl terminal-Σ-iso = declare-record-iso terminal-Σ-iso (quote Terminal)
+
+  Terminal≃is-terminal
+    : Terminal C ≃ (Σ[ apex ∈ Ob ] is-terminal C apex)
+  Terminal≃is-terminal = Iso→Equiv terminal-Σ-iso
+
+  -- Flattened record to make constructing terminal objects using
+  -- 'record where' and 'record { Module }' easier.
+  record make-terminal : Type (o ⊔ ℓ) where
+    field
+      top : Ob
+      ! : ∀ {x} → Hom x top
+      !-unique : ∀ {x} (h : Hom x top) → h ≡ !
+
+  to-terminal : make-terminal → Terminal C
+  {-# INLINE to-terminal #-}
+  to-terminal mk = record
+    { top = top
+    ; has-is-term = record
+      { ! = !
+      ; !-unique = !-unique
+      }
+    }
+    where open make-terminal mk
+
+unquoteDecl Terminal-path = declare-record-path Terminal-path (quote Terminal)
+```
+-->
+
+## Universal property
+
+<!--
+```agda
+module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Reasoning C
+  open Terminal
+```
+-->
+
+If the type of morphisms into an object $t : \cC$ is [[contractible]],
+then $t$ must be a terminal object.
 
 ```agda
-    ! : ∀ {x} → Hom x top
-    ! = has⊤ _ .centre
+  hom-contr→is-terminal
+    : ∀ {t}
+    → (∀ x → is-contr (Hom x t))
+    → is-terminal C t
+  {-# INLINE hom-contr→is-terminal #-}
+  hom-contr→is-terminal hom-contr = record
+    { ! = λ {x} → hom-contr x .centre
+    ; !-unique = λ {x} h → sym (hom-contr x .paths h)
+    }
+```
 
-    !-unique : ∀ {x} (h : Hom x top) → ! ≡ h
-    !-unique = has⊤ _ .paths
+We can further strengthen this implication to an if-and-only-if.
 
-    !-unique₂ : ∀ {x} (f g : Hom x top) → f ≡ g
-    !-unique₂ = is-contr→is-prop (has⊤ _)
+```agda
+  is-terminal→hom-contr
+    : ∀ {t}
+    → is-terminal C t
+    → (∀ x → is-contr (Hom x t))
 
-  open Terminal
+  is-terminal-univ
+    : ∀ {t}
+    → is-terminal C t ≃ (∀ x → is-contr (Hom x t))
+```
+
+<details>
+<summary>This holds essentially by definition, so we elide the details.
+</summary>
+```agda
+  is-terminal→hom-contr term x = contr t.! λ h → sym (t.!-unique h) where
+    module t = is-terminal term
+
+  is-terminal-univ {t = t} = prop-ext! is-terminal→hom-contr hom-contr→is-terminal
+```
+</details>
+
+We can also state this universal property in terms of [[equivalences]]:
+an object $t$ is terminal if and only if the constant map $\cC(x, t) \to \top$
+is an equivalence for every $x : \cC$.
+
+```agda
+  is-terminal≃comparison-equiv
+    : ∀ {t}
+    → is-terminal C t ≃ (∀ x → is-equiv λ (h : Hom x t) → tt)
+  is-terminal≃comparison-equiv {t = t} =
+    is-terminal C t                            ≃⟨ is-terminal-univ ⟩
+    (∀ x → is-contr (Hom x t))                 ≃˘⟨ Π-ap-cod (λ x → Π-contr-eqv ⊤-is-contr ∙e is-hlevel-ap 0 (const-fibre-prop≃ (hlevel 1) tt tt)) ⟩
+    (∀ x → ⊤ → is-contr (Hom x t × tt ≡ tt))   ≃˘⟨ Π-ap-cod (λ x → is-equiv≃fibre-is-contr) ⟩
+    (∀ x → is-equiv (λ h → tt))                ≃∎
 ```
 
 ## Uniqueness
@@ -62,32 +175,43 @@ inhabit a contractible space, namely the space of maps into $t_2$, so
 they are equal.
 
 ```agda
-  !-invertible : (t1 t2 : Terminal) → is-invertible (! t1 {top t2})
-  !-invertible t1 t2 = make-invertible (! t2) (!-unique₂ t1 _ _) (!-unique₂ t2 _ _)
+  module _ {t} (t-term : is-terminal C t) where
+    private
+      module t = is-terminal t-term
 
-  ⊤-unique : (t1 t2 : Terminal) → top t1 ≅ top t2
-  ⊤-unique t1 t2 = invertible→iso (! t2) (!-invertible t2 t1)
+    !-invertible→is-terminal
+      : ∀ {x} → is-invertible (t.! {x})
+      → is-terminal C x
+    {-# INLINE !-invertible→is-terminal #-}
+    !-invertible→is-terminal !-inv = record
+      { ! = λ {x} → !.inv ∘ t.!
+      ; !-unique = λ h → post-invl.from !-inv (t.!-unique (t.! ∘ h))
+      }
+      where module ! = is-invertible (!-inv)
+
+  !-invertible : (t1 t2 : Terminal C) → is-invertible (t1 .! {top t2})
+  !-invertible t1 t2 = make-invertible (t2 .!) (!-unique₂ t1 _ _) (!-unique₂ t2 _ _)
+
+  ⊤-unique : (t1 t2 : Terminal C) → top t1 ≅ top t2
+  ⊤-unique t1 t2 = invertible→iso (t2 .!) (!-invertible t2 t1)
 ```
 
 Hence, if $C$ is additionally a category, it has a propositional space of
 terminal objects:
 
 ```agda
-  ⊤-is-prop : is-category C → is-prop Terminal
-  ⊤-is-prop ccat x1 x2 i .top =
-    ccat .to-path (⊤-unique x1 x2) i
+  ⊤-is-prop : is-category C → is-prop (Terminal C)
+  ⊤-is-prop ccat x1 x2 = Terminal-path (ccat .to-path (⊤-unique x1 x2))
 
-  ⊤-is-prop ccat x1 x2 i .has⊤ ob =
-    is-prop→pathp
-      (λ i → is-contr-is-prop {A = Hom _
-        (ccat .to-path (⊤-unique x1 x2) i)})
-      (x1 .has⊤ ob) (x2 .has⊤ ob) i
+  is-terminal-iso : ∀ {A B} → A ≅ B → is-terminal C A → is-terminal C B
+  is-terminal-iso {B = B} isom A-term = B-term where
+    module isom = _≅_ isom
+    module A = is-terminal A-term
+    open is-terminal
 
-  is-terminal-iso : ∀ {A B} → A ≅ B → is-terminal A → is-terminal B
-  is-terminal-iso isom term x = contr (isom .to ∘ term x .centre) λ h →
-    isom .to ∘ term x .centre ≡⟨ ap (isom .to ∘_) (term x .paths _) ⟩
-    isom .to ∘ isom .from ∘ h ≡⟨ cancell (isom .invl) ⟩
-    h                         ∎
+    B-term : is-terminal C B
+    B-term .! = isom.to ∘ A.!
+    B-term .!-unique h = pre-invl.to (iso→invertible isom) (A.!-unique (isom.from ∘ h))
 ```
 
 ## In terms of right adjoints
@@ -96,18 +220,23 @@ We prove that the inclusion functor of an object $x$ of $\cC$ is right adjoint
 to the unique functor $\cC \to \top$ if and only if $x$ is terminal.
 
 ```agda
-  module _ (x : Ob) (term : is-terminal x) where
-    is-terminal→inclusion-is-right-adjoint : !F ⊣ !Const {C = C} x
-    is-terminal→inclusion-is-right-adjoint =
-      hom-iso→adjoints (e _ .fst) (e _ .snd)
-        λ _ _ _ → term _ .paths _
-      where
-        e : ∀ y → ⊤ ≃ Hom y x
-        e y = is-contr→≃ (hlevel 0) (term y)
+  is-terminal→inclusion-is-right-adjoint
+    : ∀ (x : Ob) → is-terminal C x
+    → !F ⊣ !Const {C = C} x
+  is-terminal→inclusion-is-right-adjoint x term =
+    hom-iso→adjoints (e _ .fst) (e _ .snd)
+      λ _ _ _ → is-terminal.!-unique₂ term _ _
+    where
+      e : ∀ y → ⊤ ≃ Hom y x
+      e y = is-contr→≃ (hlevel 0) (is-terminal→hom-contr term y)
 
-  module _ (x : Ob) (adj : !F ⊣ !Const {C = C} x) where
-    inclusion-is-right-adjoint→is-terminal : is-terminal x
-    inclusion-is-right-adjoint→is-terminal y = Equiv→is-hlevel 0
+  inclusion-is-right-adjoint→is-terminal
+    : ∀ (x : Ob) (adj : !F ⊣ !Const {C = C} x)
+    → is-terminal C x
+  {-# INLINE inclusion-is-right-adjoint→is-terminal #-}
+  inclusion-is-right-adjoint→is-terminal x adj =
+    hom-contr→is-terminal λ y →
+    Equiv→is-hlevel 0
       (Σ-contr-snd (λ _ → hlevel 0) e⁻¹)
       (R-adjunct-is-equiv adj .is-eqv _)
 ```

--- a/src/Cat/Diagram/Terminal.lagda.md
+++ b/src/Cat/Diagram/Terminal.lagda.md
@@ -77,6 +77,16 @@ module _ {o ℓ} {C : Precategory o ℓ} where
     : Terminal C ≃ (Σ[ apex ∈ Ob ] is-terminal C apex)
   Terminal≃is-terminal = Iso→Equiv terminal-Σ-iso
 
+  instance
+    Extensional-Terminal
+      : ∀ {ℓr}
+      → ⦃ sa : Extensional Ob ℓr ⦄
+      → Extensional (Terminal C) ℓr
+    Extensional-Terminal ⦃ sa ⦄ =
+      embedding→extensional
+        (Equiv→Embedding Terminal≃is-terminal ∙emb (fst , Subset-proj-embedding (λ _ → hlevel 1)))
+        sa
+
   -- Flattened record to make constructing terminal objects using
   -- 'record where' and 'record { Module }' easier.
   record make-terminal : Type (o ⊔ ℓ) where
@@ -96,7 +106,6 @@ module _ {o ℓ} {C : Precategory o ℓ} where
     }
     where open make-terminal mk
 
-unquoteDecl Terminal-path = declare-record-path Terminal-path (quote Terminal)
 ```
 -->
 
@@ -201,7 +210,7 @@ terminal objects:
 
 ```agda
   ⊤-is-prop : is-category C → is-prop (Terminal C)
-  ⊤-is-prop ccat x1 x2 = Terminal-path (ccat .to-path (⊤-unique x1 x2))
+  ⊤-is-prop ccat x1 x2 = ext (ccat .to-path (⊤-unique x1 x2))
 
   is-terminal-iso : ∀ {A B} → A ≅ B → is-terminal C A → is-terminal C B
   is-terminal-iso {B = B} isom A-term = B-term where
@@ -240,21 +249,3 @@ to the unique functor $\cC \to \top$ if and only if $x$ is terminal.
       (Σ-contr-snd (λ _ → hlevel 0) e⁻¹)
       (R-adjunct-is-equiv adj .is-eqv _)
 ```
-
-<!--
-```agda
-module _ {o h} {C : Precategory o h} where
-  open Cat.Reasoning C
-  private unquoteDecl eqv = declare-record-iso eqv (quote Terminal)
-
-  instance
-    Extensional-Terminal
-      : ∀ {ℓr}
-      → ⦃ sa : Extensional Ob ℓr ⦄
-      → Extensional (Terminal C) ℓr
-    Extensional-Terminal ⦃ sa ⦄ =
-      embedding→extensional
-        (Iso→Embedding eqv ∙emb (fst , Subset-proj-embedding (λ _ → hlevel 1)))
-        sa
-```
--->

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -39,7 +39,7 @@ coincide. When this occurs, we call the object a **zero object**.
     open is-zero has-is-zero public
 
     terminal : Terminal C
-    terminal = record { top = ∅ ; has⊤ = has-is-terminal }
+    terminal = record { top = ∅ ; has-is-term = has-is-terminal }
 
     initial : Initial C
     initial = record { bot = ∅ ; has⊥ = has-is-initial }
@@ -62,7 +62,7 @@ $0 = ¡ \circ ! : x \to y$ is called the **zero morphism**.
     zero-∘l f = pulll (sym (¡-unique (f ∘ ¡)))
 
     zero-∘r : ∀ {x y z} → (f : Hom x y) → zero→ {y} {z} ∘ f ≡ zero→
-    zero-∘r f = pullr (sym (!-unique (! ∘ f)))
+    zero-∘r f = pullr (!-unique (! ∘ f))
 
     zero-comm : ∀ {x y z} → (f : Hom y z) → (g : Hom x y) → f ∘ zero→ ≡ zero→ ∘ g
     zero-comm f g = zero-∘l f ∙ sym (zero-∘r g)

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -27,11 +27,13 @@ coincide. When this occurs, we call the object a **zero object**.
 
 ```agda
   record is-zero (ob : Ob) : Type (o ⊔ h) where
+    no-eta-equality
     field
       has-is-initial  : is-initial C ob
       has-is-terminal : is-terminal C ob
 
   record Zero : Type (o ⊔ h) where
+    no-eta-equality
     field
       ∅       : Ob
       has-is-zero : is-zero ∅
@@ -42,7 +44,7 @@ coincide. When this occurs, we call the object a **zero object**.
     terminal = record { top = ∅ ; has-is-term = has-is-terminal }
 
     initial : Initial C
-    initial = record { bot = ∅ ; has⊥ = has-is-initial }
+    initial = record { bot = ∅ ; has-is-init = has-is-initial }
 
     open Terminal terminal public hiding (top)
     open Initial initial public hiding (bot)
@@ -59,7 +61,7 @@ $0 = ¡ \circ ! : x \to y$ is called the **zero morphism**.
     zero→ = ¡ ∘ !
 
     zero-∘l : ∀ {x y z} → (f : Hom y z) → f ∘ zero→ {x} {y} ≡ zero→
-    zero-∘l f = pulll (sym (¡-unique (f ∘ ¡)))
+    zero-∘l f = pulll (¡-unique (f ∘ ¡))
 
     zero-∘r : ∀ {x y z} → (f : Hom x y) → zero→ {y} {z} ∘ f ≡ zero→
     zero-∘r f = pullr (!-unique (! ∘ f))
@@ -101,6 +103,9 @@ earlier acts as the designated basepoint for each of the hom sets.
 
 <!--
 ```agda
+{-# INLINE is-zero.constructor #-}
+{-# INLINE Zero.constructor #-}
+
 module _ {o h} {C : Precategory o h} where
   open Cat.Reasoning C
   private unquoteDecl is-zero-eqv = declare-record-iso is-zero-eqv (quote is-zero)
@@ -122,5 +127,26 @@ module _ {o h} {C : Precategory o h} where
       embedding→extensional
         (Iso→Embedding zero-eqv ∙emb (fst , Subset-proj-embedding (λ _ → hlevel 1)))
         sa
+
+  record make-is-zero (∅ : Ob) : Type (o ⊔ h) where
+    field
+      ! : ∀ {x} → Hom x ∅
+      ¡ : ∀ {x} → Hom ∅ x
+      !-unique : ∀ {x} (h : Hom x ∅) → h ≡ !
+      ¡-unique : ∀ {x} (h : Hom ∅ x) → h ≡ ¡
+
+  to-is-zero : ∀ {∅} → make-is-zero ∅ → is-zero C ∅
+  {-# INLINE to-is-zero #-}
+  to-is-zero mk = record
+    { has-is-initial = record
+      { ¡ = ¡
+      ; ¡-unique = ¡-unique
+      }
+    ; has-is-terminal = record
+      { ! = !
+      ; !-unique = !-unique
+      }
+    }
+    where open make-is-zero mk
 ```
 -->

--- a/src/Cat/Displayed/Diagram/Total/Terminal.lagda.md
+++ b/src/Cat/Displayed/Diagram/Total/Terminal.lagda.md
@@ -34,33 +34,33 @@ displayed over $!$.
 
 ```agda
 record is-terminal-over {top} (term : is-terminal B top) (top' : E ʻ top) : Type (o ⊔ o' ⊔ ℓ') where
-  open Terminal {C = B} record{ has⊤ = term } hiding (top)
+  open is-terminal term
   field
     !'        : ∀ {y} {y' : E ʻ y} → E.Hom[ ! ] y' top'
-    !-unique' : ∀ {y} {y' : E ʻ y} (h : E.Hom[ ! ] y' top') → !' ≡ h
+    !-unique' : ∀ {y} {y' : E ʻ y} (h : E.Hom[ ! ] y' top') → h ≡ !'
 
   opaque
     !ₚ : ∀ {y} {m : B.Hom y top} {y' : E ʻ y} → E.Hom[ m ] y' top'
-    !ₚ {m = m} = E.hom[ !-unique m ] !'
+    !ₚ {m = m} = E.hom[ sym $ !-unique m ] !'
 
     abstract
-      !ₚ-unique : ∀ {y} {m : B.Hom y top} {y' : E ʻ y} (h : E.Hom[ m ] y' top') → !ₚ ≡ h
+      !ₚ-unique : ∀ {y} {m : B.Hom y top} {y' : E ʻ y} (h : E.Hom[ m ] y' top') → h ≡ !ₚ
       !ₚ-unique {m = m} {y'} = J
-        (λ m p → (h : E.Hom[ m ] y' top') → E.hom[ p ] !' ≡ h)
-        (λ h → E.from-pathp[] (!-unique' h))
-        (!-unique m)
+        (λ m p → (h : E.Hom[ m ] y' top') → h ≡ E.hom[ p ] !')
+        (λ h → E.from-pathp[]⁻ (!-unique' h))
+        (sym $ !-unique m)
 
   abstract
     !'-unique₂
       : ∀ {y} {m m' : B.Hom y top} {y' : E ʻ y} {h : E.Hom[ m ] y' top'} {h' : E.Hom[ m' ] y' top'}
       → {p : m ≡ m'}
       → h E.≡[ p ] h'
-    !'-unique₂ {h = h} {h' = h'} = to-pathp (sym (!ₚ-unique _) ∙ !ₚ-unique _)
+    !'-unique₂ {h = h} {h' = h'} = to-pathp ((!ₚ-unique _) ∙ sym (!ₚ-unique _))
 
 record TerminalP (t : Terminal B) : Type (o ⊔ o' ⊔ ℓ') where
   open Terminal t
   field
     top'  : E ʻ top
-    has⊤' : is-terminal-over has⊤ top'
+    has⊤' : is-terminal-over has-is-term top'
   open is-terminal-over has⊤' public
 ```

--- a/src/Cat/Displayed/Doctrine/Frame.lagda.md
+++ b/src/Cat/Displayed/Doctrine/Frame.lagda.md
@@ -97,7 +97,8 @@ function which is constantly the top element.
 ```agda
   term : ∀ S → Terminal (Fibre disp S)
   term S .top  _ = F.top
-  term S .has⊤ f = is-prop∙→is-contr (hlevel 1) (λ i → F.!)
+  term S .has-is-term .is-terminal.! _ = F.!
+  term S .has-is-term .is-terminal.!-unique _ = prop!
 ```
 
 ## As a fibration

--- a/src/Cat/Displayed/Instances/Gluing.lagda.md
+++ b/src/Cat/Displayed/Instances/Gluing.lagda.md
@@ -123,10 +123,10 @@ $\cC$, while the morphisms are induced by $F$'s comparison maps.
 
 ```agda
 Gl-terminal : TerminalP Gl D.terminal
-Gl-terminal .top'      = cut {dom = C.top} (pres-terminal _ .centre)
+Gl-terminal .top'      = cut {dom = C.top} (is-terminal.! image-is-terminal)
 Gl-terminal .has⊤' .!' = record
   { map = C.!
-  ; com = is-contr→is-prop (pres-terminal _) _ _
+  ; com = is-terminal.!-unique₂ image-is-terminal _ _
   }
 Gl-terminal .has⊤' .!-unique' h = Slice-pathp (C.!-unique _)
 ```

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -478,7 +478,8 @@ opaque
 
 Sub-terminal : ∀ {y} → Terminal (Sub y)
 Sub-terminal .Terminal.top = ⊤ₘ
-Sub-terminal .Terminal.has⊤ m = contr !ₘ λ _ → prop!
+Sub-terminal .Terminal.has-is-term .is-terminal.! = !ₘ
+Sub-terminal .Terminal.has-is-term .is-terminal.!-unique _ = prop!
 ```
 
 Since products in slice categories are given by pullbacks, and pullbacks

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -520,11 +520,13 @@ equivalence, but it would not be very useful, either.
 ```agda
   free-object→universal-map
     : ∀ {X} → Free-object U X → Initial (X ↙ U)
-  free-object→universal-map fo = λ where
-    .I.bot → ↓obj (fo .unit)
-    .I.has⊥ x .centre  → ↓hom (D.idr _ ∙ sym (fo .commute))
-    .I.has⊥ x .paths p → ↓Hom-path _ _ refl $ sym $
-      fo .unique _ (sym (p .com) ∙ D.idr _)
+  {-# INLINE free-object→universal-map #-}
+  free-object→universal-map fo = to-initial $ record
+    { bot = ↓obj X.unit
+    ; ¡ = ↓hom (D.idr _ ∙ sym X.commute)
+    ; ¡-unique = λ f → ↓Hom-path _ _ refl $ X.unique _ (sym (f .com) ∙ D.idr _)
+    }
+    where module X = Free-object fo
 ```
 
 ### Free objects and adjoints
@@ -699,9 +701,8 @@ $A$ is an initial object in $\cC$.
     free-on-initial→initial
       : (F[⊥] : Free-object U init)
       → is-initial C (F[⊥] .free)
-    free-on-initial→initial F[⊥] x .centre = F[⊥] .fold ¡
-    free-on-initial→initial F[⊥] x .paths f =
-      sym $ F[⊥] .unique f (sym (¡-unique _))
+    free-on-initial→initial F[⊥] .is-initial.¡ = F[⊥] .fold ¡
+    free-on-initial→initial F[⊥] .is-initial.¡-unique f = F[⊥] .unique f (¡-unique _)
 ```
 
 Conversely, if $\cC$ has an initial object $\bot_{\cC}$, then $\bot_{\cC}$
@@ -874,10 +875,10 @@ module _ {o h o' h'} {C : Precategory o h} {D : Precategory o' h'} where
   universal-map→free-object : ∀ {R X} → Universal-morphism R X → Free-object R X
   universal-map→free-object x .free = _
   universal-map→free-object x .unit = x .bot .map
-  universal-map→free-object x .fold f = x .has⊥ (↓obj f) .centre .bot
-  universal-map→free-object x .commute = sym (x .has⊥ _ .centre .com) ∙ C.idr _
+  universal-map→free-object x .fold f = x .¡ {↓obj f} .bot
+  universal-map→free-object x .commute = sym (x .¡ .com) ∙ C.idr _
   universal-map→free-object x .unique g p = ap bot
-    (sym (x .has⊥ _ .paths (↓hom (sym (p ∙ sym (C.idr _))))))
+    (x .¡-unique (↓hom (sym (p ∙ sym (C.idr _)))))
 
   universal-maps→functor : ∀ {R} → (∀ X → Universal-morphism R X) → Functor C D
   universal-maps→functor u = free-objects→functor

--- a/src/Cat/Functor/Adjoint/Continuous.lagda.md
+++ b/src/Cat/Functor/Adjoint/Continuous.lagda.md
@@ -145,12 +145,11 @@ if we do it by hand.
 
   right-adjoint→terminal
     : ∀ {x} → is-terminal D x → is-terminal C (R.₀ x)
-  right-adjoint→terminal term x = contr fin uniq where
-    fin = L-adjunct L⊣R (term (L.₀ x) .centre)
-    uniq : ∀ x → fin ≡ x
-    uniq x = ap fst $ is-contr→is-prop (R-adjunct-is-equiv L⊣R .is-eqv _)
-      (_ , equiv→counit (R-adjunct-is-equiv L⊣R) _)
-      (x , is-contr→is-prop (term _) _ _)
+  {-# INLINE right-adjoint→terminal #-}
+  right-adjoint→terminal term = record
+    { ! = L-adjunct L⊣R !
+    ; !-unique = λ h → sym $ Equiv.adjunctr (_ , L-adjunct-is-equiv L⊣R) (sym (!-unique _))
+    } where open is-terminal term
 
   right-adjoint→lex : is-lex R
   right-adjoint→lex .is-lex.pres-⊤ =

--- a/src/Cat/Functor/Adjoint/Hom.lagda.md
+++ b/src/Cat/Functor/Adjoint/Hom.lagda.md
@@ -136,6 +136,27 @@ of adjunction units and co-units.
 
 <!--
 ```agda
+  hom-iso≃adjoints
+    : (Σ[ e ∈ (∀ {x y} → C.Hom (L.₀ x) y ≃ D.Hom x (R.₀ y)) ] hom-iso-natural λ {x} {y} → Equiv.to (e {x} {y}))
+    ≃ (L ⊣ R)
+  hom-iso≃adjoints .fst (e , e-natural) =
+    hom-iso→adjoints (λ {x} {y} → e .fst) (λ {x} {y} → e .snd) e-natural
+  hom-iso≃adjoints .snd = is-iso→is-equiv λ where
+    .is-iso.from L⊣R → adjunct-hom-equiv L⊣R , L-adjunct-natural₂ L⊣R
+    .is-iso.rinv L⊣R →
+      adjoint-pathp refl refl
+        (ext λ d → D.eliml R.F-id)
+        (ext λ c → C.elimr L.F-id)
+    .is-iso.linv (e , e-nat) → Σ-prop-path! $ ext λ f →
+        R.F₁ f D.∘ Equiv.to e C.id            ≡˘⟨ D.cdr (D.idr _) ⟩
+        R.F₁ f D.∘ Equiv.to e C.id D.∘ D.id   ≡˘⟨ e-nat f D.id C.id ⟩
+        Equiv.to e (f C.∘ C.id C.∘ L.₁ D.id)  ≡⟨ ap (Equiv.to e) (C.elimr (C.elimr L.F-id)) ⟩
+        Equiv.to e f                          ∎
+```
+-->
+
+<!--
+```agda
   hom-iso-inv-natural
     : (f : ∀ {x y} → D.Hom x (R.₀ y) → C.Hom (L.₀ x) y)
     → Type _
@@ -153,6 +174,23 @@ of adjunction units and co-units.
     abstract
       nat : hom-iso-natural f.from
       nat g h x = f.injective (f.ε _ ∙ sym (natural _ _ _ ∙ ap (g C.∘_) (ap (C._∘ L.₁ h) (f.ε _))))
+
+  hom-iso-inv≃adjoints
+    : (Σ[ e ∈ (∀ {x y} → D.Hom x (R.₀ y) ≃ C.Hom (L.₀ x) y) ] hom-iso-inv-natural λ {x} {y} → Equiv.to (e {x} {y}))
+    ≃ (L ⊣ R)
+  hom-iso-inv≃adjoints .fst (e , e-natural) =
+    hom-iso-inv→adjoints (λ {x} {y} → e .fst) (λ {x} {y} → e .snd) e-natural
+  hom-iso-inv≃adjoints .snd = is-iso→is-equiv λ where
+    .is-iso.from L⊣R → (λ {x y} → adjunct-hom-equiv L⊣R e⁻¹) , R-adjunct-natural₂ L⊣R
+    .is-iso.rinv L⊣R →
+      adjoint-pathp refl refl
+        (ext λ d → D.eliml R.F-id)
+        (ext λ c → C.elimr L.F-id)
+    .is-iso.linv (e , e-nat) → Σ-prop-path! $ ext λ f →
+      Equiv.to e D.id C.∘ L.F₁ f           ≡˘⟨ C.idl _ ⟩
+      C.id C.∘ Equiv.to e D.id C.∘ L.F₁ f  ≡˘⟨ e-nat C.id f D.id ⟩
+      Equiv.to e (R.₁ C.id D.∘ D.id D.∘ f) ≡⟨ ap (Equiv.to e) (D.cancell (D.eliml R.F-id)) ⟩
+      Equiv.to e f                         ∎
 
 module _ {o ℓ o'} {C : Precategory o ℓ} {D : Precategory o' ℓ}
          {L : Functor D C} {R : Functor C D}

--- a/src/Cat/Functor/Algebra.lagda.md
+++ b/src/Cat/Functor/Algebra.lagda.md
@@ -152,8 +152,10 @@ also be an inverse, so $\alpha$ is invertible.
   lambek {a} α initial = inverses→invertible $
     algebra-section→inverses α unroll roll-unroll
     where
+      module α = is-initial initial
+
       unroll : FAlg.Hom (a , α) (F.₀ a , F.₁ α)
-      unroll = initial (F.₀ a , F.₁ α) .centre
+      unroll = α.¡ {F.₀ a , F.₁ α}
 
       roll : FAlg.Hom (F.₀ a , F.₁ α) (a , α)
       roll .fst = α
@@ -161,8 +163,7 @@ also be an inverse, so $\alpha$ is invertible.
 
       roll-unroll : α ∘ unroll .fst ≡ id
       roll-unroll =
-        ap fst $
-        is-contr→is-prop (initial (a , α)) (roll FAlg.∘ unroll) FAlg.id
+        ap fst $ α.¡-unique₂ (roll FAlg.∘ unroll) FAlg.id
 ```
 
 This result means that an initial $F$-algebra $(A, \alpha)$ is a fixpoint of the
@@ -231,7 +232,7 @@ where $\omega$ is the [[poset of natural numbers]], regarded as a category.
 
 ```agda
     Fⁿ[⊥]-id : ∀ n → F₁ⁿ[⊥] (≤-refl {n}) ≡ id
-    Fⁿ[⊥]-id zero = ¡-unique id
+    Fⁿ[⊥]-id zero = sym $ ¡-unique id
     Fⁿ[⊥]-id (suc n) = F.elim (Fⁿ[⊥]-id n)
 
     Fⁿ[⊥]-∘
@@ -261,7 +262,7 @@ in $n$.
       : ∀ {a} {α : Hom (F.₀ a) a} {m n}
       → (m≤n : m ≤ n)
       → Fⁿ[⊥]-fold α n ∘ F₁ⁿ[⊥] m≤n ≡ Fⁿ[⊥]-fold α m
-    Fⁿ[⊥]-fold-nat {m = 0} {n = n} m≤n = sym (¡-unique _)
+    Fⁿ[⊥]-fold-nat {m = 0} {n = n} m≤n = ¡-unique _
     Fⁿ[⊥]-fold-nat {m = suc m} {n = suc n} m≤n = F.pullr (Fⁿ[⊥]-fold-nat (≤-peel m≤n))
 ```
 
@@ -318,7 +319,7 @@ paired with the universal property of $F^{\infty}(\bot)$.
         → (f : Hom ∐Fⁿ[⊥] a)
         → f ∘ roll ≡ α ∘ F.₁ f
         → ∀ n → f ∘ ∐Fⁿ[⊥].ψ n ≡ Fⁿ[⊥]-fold α n
-      fold-step {α = α} f p zero = sym (¡-unique _)
+      fold-step {α = α} f p zero = ¡-unique _
       fold-step {α = α} f p (suc n) =
          f ∘ ∐Fⁿ[⊥].ψ (suc n)               ≡˘⟨ ap (f ∘_) (F[∐Fⁿ[⊥]].factors _ _) ⟩
          f ∘ roll ∘ F.F₁ (∐Fⁿ[⊥].ψ n)       ≡⟨ pulll p ⟩
@@ -329,8 +330,8 @@ paired with the universal property of $F^{\infty}(\bot)$.
         : ∀ {a} {α : Hom (F.₀ a) a}
         → (f : Hom ∐Fⁿ[⊥] a)
         → f ∘ roll ≡ α ∘ F.₁ f
-        → fold α ≡ f
-      fold-unique f p = sym $ ∐Fⁿ[⊥].unique _ _ _ (fold-step f p)
+        → f ≡ fold α
+      fold-unique f p = ∐Fⁿ[⊥].unique _ _ _ (fold-step f p)
 ```
 
 If we put all the pieces together, we observe that $(F^{\infty}(\bot), \mathrm{roll})$
@@ -340,9 +341,9 @@ is an initial $F$-algebra.
       ∐Fⁿ[⊥]-initial : Initial FAlg
       ∐Fⁿ[⊥]-initial .Initial.bot .fst = ∐Fⁿ[⊥]
       ∐Fⁿ[⊥]-initial .Initial.bot .snd = roll
-      ∐Fⁿ[⊥]-initial .Initial.has⊥ (a , α) .centre .fst = fold α
-      ∐Fⁿ[⊥]-initial .Initial.has⊥ (a , α) .centre .snd = fold-roll α
-      ∐Fⁿ[⊥]-initial .Initial.has⊥ (a , α) .paths f =
+      ∐Fⁿ[⊥]-initial .Initial.has-is-init .is-initial.¡ {a , α} .fst = fold α
+      ∐Fⁿ[⊥]-initial .Initial.has-is-init .is-initial.¡ {a , α} .snd = fold-roll α
+      ∐Fⁿ[⊥]-initial .Initial.has-is-init .is-initial.¡-unique f =
         ∫Hom-path F-Algebras (fold-unique (f .fst) (f .snd)) prop!
 ```
 

--- a/src/Cat/Functor/Algebra/KnasterTarski.lagda.md
+++ b/src/Cat/Functor/Algebra/KnasterTarski.lagda.md
@@ -102,7 +102,7 @@ applying [[Lambek's lemma]] to the resulting initial algebra.
     → is-weak-initial-fam (FAlg F) Aᵢ
     → Σ[ Fix ∈ Ob ] (F₀ Fix ≅ Fix)
   solution-set→fixpoint Aᵢ complete soln-set =
-    bot .fst , invertible→iso (bot .snd) (lambek F (bot .snd) has⊥)
+    bot .fst , invertible→iso (bot .snd) (lambek F (bot .snd) has-is-init)
     where open Initial (solution-set→initial-algebra Aᵢ complete soln-set)
 ```
 

--- a/src/Cat/Functor/Final.lagda.md
+++ b/src/Cat/Functor/Final.lagda.md
@@ -355,8 +355,9 @@ terminal→inclusion-is-final
   : ∀ {o ℓ} {𝒞 : Precategory o ℓ}
   → (top : 𝒞 .Ob) (term : is-terminal 𝒞 top)
   → is-final (!Const {C = 𝒞} top)
-terminal→inclusion-is-final top term = right-adjoint-is-final
-  (is-terminal→inclusion-is-right-adjoint _ top term)
+terminal→inclusion-is-final top term =
+  right-adjoint-is-final
+  $ is-terminal→inclusion-is-right-adjoint _ term
 ```
 
 ## Closure under composition

--- a/src/Cat/Functor/Hom/Coyoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Coyoneda.lagda.md
@@ -203,8 +203,8 @@ _also_ a cocone homomorphism $X \to Y$; But $X$ is initial, so $f = g$!
 
 ```agda
   Representables-generate-presheaf {f} {g} sep =
-    ap map $ is-contr→is-prop
-      (is-colimit→is-initial-cocone _ (coyoneda X) (Map→cocone-under X f))
+    ap map $ is-initial.¡-unique₂
+      (is-colimit→is-initial-cocone _ (coyoneda X))
       f' g'
     where
       f' : Cocone-hom (よ F∘ πₚ C X) _ (Map→cocone-under X f)

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -333,53 +333,51 @@ corepresentation→initial-element
 <summary>The proofs are again entirely analogous to the representable case.</summary>
 
 ```agda
+{-# INLINE initial-element→corepresentation #-}
 initial-element→corepresentation {F} init = f-corep where
   module F = Functor F
   open Initial init
   open Co.Element-hom
   nat : F => Hom-from C (bot .fst)
-  nat .η ob section = has⊥ (Co.elem ob section) .centre .hom
-  nat .is-natural x y f = funext λ sect → ap hom $ has⊥ _ .paths $ Co.elem-hom _ $
-    F.₁ (f C.∘ has⊥ _ .centre .hom) (bot .snd)   ≡⟨ happly (F.F-∘ _ _) _ ⟩
-    F.₁ f (F.₁ (has⊥ _ .centre .hom) (bot .snd)) ≡⟨ ap (F.₁ f) (has⊥ _ .centre .commute) ⟩
-    F.₁ f sect                                   ∎
+  nat .η ob section = ¡ {Co.elem ob section} .hom
+  nat .is-natural x y f = funext λ sect →
+    ap hom $ sym $ ¡-unique $ Co.elem-hom _ $
+    F.₁ (f C.∘ ¡ .hom) (bot .snd)   ≡⟨ happly (F.F-∘ _ _) _ ⟩
+    F.₁ f (F.₁ (¡ .hom) (bot .snd)) ≡⟨ ap (F.₁ f) (¡ .commute) ⟩
+    F.₁ f sect                      ∎
 
   inv : ∀ x → Sets.is-invertible (nat .η x)
   inv x = Sets.make-invertible
     (λ f → F.₁ f (bot .snd))
-    (funext λ x → ap hom $ has⊥ _ .paths (Co.elem-hom x refl))
-    (funext λ x → has⊥ _ .centre .commute)
+    (funext λ x → ap hom $ sym $ ¡-unique (Co.elem-hom x refl))
+    (funext λ x → ¡ .commute)
 
   f-corep : Corepresentation F
   f-corep .corep = bot .fst
   f-corep .corepresents = [C,Sets].invertible→iso nat $
     invertible→invertibleⁿ nat inv
 
-corepresentation→initial-element {F} F-corep = init where
-  module F = Functor F
-  module R = corep F-corep
-  open Initial
-  open Co.Element-hom
-
-  init : Initial (Co.∫ F)
-  init .bot .fst = F-corep .corep
-  init .bot .snd = R.from .η _ C.id
-  init .has⊥ (Co.elem o s) .centre .hom = R.to .η _ s
-  init .has⊥ (Co.elem o s) .centre .commute =
-    F.₁ (R.to .η o s) (R.from .η _ C.id) ≡˘⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
-    R.from .η _ ⌜ R.to .η o s C.∘ C.id ⌝ ≡⟨ ap! (C.idr _) ⟩
-    R.from .η _ (R.to .η o s)            ≡⟨ unext R.invr o s ⟩
-    s                                    ∎
-  init .has⊥ (Co.elem o s) .paths h = ext $
-    R.to .η o ⌜ s ⌝                  ≡˘⟨ ap¡ comm ⟩
-    R.to .η o (R.from .η _ (h .hom)) ≡⟨ unext R.invl o _ ⟩
-    h .hom                           ∎
-    where
-      comm =
-        R.from .η _ ⌜ h .hom ⌝          ≡˘⟨ ap¡ (C.idr _) ⟩
-        R.from .η _ (h .hom C.∘ C.id)   ≡⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
-        F.₁ (h .hom) (R.from .η _ C.id) ≡⟨ h .commute ⟩
-        s                               ∎
+corepresentation→initial-element {F} F-corep = record
+  { bot = F-corep .corep , R.from .η (F-corep .corep) C.id
+  ; has-is-init = record
+    { ¡ = λ {x} → Co.elem-hom (R.to .η (x .fst) (x .snd)) $
+      F.₁ (R.to .η _ (x .snd)) (R.from .η _ C.id) ≡˘⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
+      R.from .η _ ⌜ R.to .η _ (x .snd) C.∘ C.id ⌝ ≡⟨ ap! (C.idr _) ⟩
+      R.from .η _ (R.to .η _ (x .snd))            ≡⟨ unext R.invr (x .fst) (x .snd) ⟩
+      x .snd                                      ∎
+    ; ¡-unique = λ {x} h → ext $
+      h .hom                                                     ≡˘⟨ unext R.invl _ _ ⟩
+      R.to .η _ (R.from .η _ (h .hom))                           ≡˘⟨ ap (R.to .η _ ⊙ R.from .η _) (C.idr _) ⟩
+      R.to .η (x .fst) (R.from .η (x .fst) (h .hom C.∘ C.id))    ≡⟨ ap (R.to .η _) (R.from .is-natural _ _ _ ·ₚ C.id) ⟩
+      R.to .η _ (F.₁ (h .hom) (R.from .η (F-corep .corep) C.id)) ≡⟨ ap (R.to .η _) (h .commute) ⟩
+      R.to .η _ (x .snd) ∎
+    }
+  }
+  where
+    module F = Functor F
+    module R = corep F-corep
+    open Initial
+    open Co.Element-hom
 ```
 </details>
 

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -153,17 +153,18 @@ constitutes a natural isomorphism.
 
 ```agda
   nat : F => よ₀ C (top .fst)
-  nat .η ob section = has⊤ (elem ob section) .centre .hom
-  nat .is-natural x y f = funext λ sect → ap hom $ has⊤ _ .paths $ elem-hom _ $
-    F.₁ (has⊤ _ .centre .hom C.∘ f) (top .snd)   ≡⟨ happly (F.F-∘ _ _) _ ⟩
-    F.₁ f (F.₁ (has⊤ _ .centre .hom) (top .snd)) ≡⟨ ap (F.₁ f) (has⊤ _ .centre .commute) ⟩
-    F.₁ f sect                                   ∎
+  nat .η ob section = ! {elem ob section} .hom
+  -- has⊤ (elem ob section) .centre .hom
+  nat .is-natural x y f = funext λ sect → ap hom $ sym $ !-unique $ elem-hom _ $
+    F.₁ (! .hom C.∘ f) (top .snd)   ≡⟨ happly (F.F-∘ _ _) _ ⟩
+    F.₁ f (F.₁ (! .hom) (top .snd)) ≡⟨ ap (F.₁ f) (! .commute) ⟩
+    F.₁ f sect                      ∎
 
   inv : ∀ x → Sets.is-invertible (nat .η x)
   inv x = Sets.make-invertible
     (λ f → F.₁ f (top .snd))
-    (funext λ x → ap hom $ has⊤ _ .paths (elem-hom x refl))
-    (funext λ x → has⊤ _ .centre .commute)
+    (funext λ x → ap hom $  sym (!-unique (elem-hom x refl)))
+    (funext λ x → ! .commute)
 
   f-rep : Representation F
   f-rep .rep = top .fst
@@ -178,30 +179,26 @@ identity on the representing object.
 representation→terminal-element
   : {F : Functor (C ^op) (Sets κ)}
   → Representation F → Terminal (∫ C F)
-representation→terminal-element {F} F-rep = term where
-  module F = Functor F
-  module R = rep F-rep
-  open Terminal
-
-  term : Terminal (∫ C F)
-  term .top .fst = F-rep .rep
-  term .top .snd = R.from .η _ C.id
-  term .has⊤ (elem o s) .centre .hom = R.to .η _ s
-  term .has⊤ (elem o s) .centre .commute =
-    F.₁ (R.to .η o s) (R.from .η _ C.id) ≡˘⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
-    R.from .η _ ⌜ C.id C.∘ R.to .η o s ⌝ ≡⟨ ap! (C.idl _) ⟩
-    R.from .η _ (R.to .η o s)            ≡⟨ unext R.invr o s ⟩
-    s                                    ∎
-  term .has⊤ (elem o s) .paths h = ext $
-    R.to .η o ⌜ s ⌝                  ≡˘⟨ ap¡ comm ⟩
-    R.to .η o (R.from .η _ (h .hom)) ≡⟨ unext R.invl o _ ⟩
-    h .hom                           ∎
-    where
-      comm =
-        R.from .η _ ⌜ h .hom ⌝          ≡˘⟨ ap¡ (C.idl _) ⟩
-        R.from .η _ (C.id C.∘ h .hom)   ≡⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
-        F.₁ (h .hom) (R.from .η _ C.id) ≡⟨ h .commute ⟩
-        s                               ∎
+{-# INLINE representation→terminal-element #-}
+representation→terminal-element {F} F-rep = record
+  { top = rep F-rep , R.from .η (rep F-rep) C.id
+  ; has-is-term = record
+    { ! = λ {x} → elem-hom (R.to .η _ (x .snd)) $
+      F.₁ (R.to .η _ _) (R.from .η _ C.id) ≡˘⟨ R.from .is-natural _ _ _ $ₚ _ ⟩
+      R.from .η _ ⌜ C.id C.∘ R.to .η _ _ ⌝ ≡⟨ ap! (C.idl _) ⟩
+      R.from .η _ (R.to .η _ _)            ≡⟨ unext R.invr (x .fst) (x .snd) ⟩
+      x .snd                               ∎
+    ; !-unique = λ {x} h → ext $
+      h .hom ≡˘⟨ unext R.invl _ _ ⟩
+      R.to .η _ (R.from .η _ (h .hom))            ≡˘⟨ ap (R.to .η _ ⊙ R.from .η _) (C.idl (h .hom)) ⟩
+      R.to .η _ (R.from .η _ (C.id C.∘ h .hom))   ≡⟨ ap (R.to .η _) (R.from .is-natural _ _ _ $ₚ _)  ⟩
+      R.to .η _ (F.₁ (h .hom) (R.from .η _ C.id)) ≡⟨ ap (R.to .η _) (h .commute) ⟩
+      R.to .η _ (x .snd) ∎
+    }
+  }
+  where
+    module F = Functor F
+    module R = rep F-rep
 ```
 
 ## Universal constructions
@@ -221,10 +218,14 @@ terminal object.
 
 ```agda
 representable-unit→terminal
-  : Representation (Const (el (Lift _ ⊤) (hlevel 2))) → Terminal C
-representable-unit→terminal repr .Terminal.top = repr .rep
-representable-unit→terminal repr .Terminal.has⊤ ob = retract→is-contr
-  (Rep.from repr) (λ _ → lift tt) (Rep.η repr) (hlevel 0)
+  : Representation (Const (el! (Lift _ ⊤)))
+  → Terminal C
+{-# INLINE representable-unit→terminal #-}
+representable-unit→terminal repr = record
+  { top = rep repr
+  ; has-is-term = hom-contr→is-terminal $ λ x →
+    retract→is-contr (Rep.from repr) (λ _ → lift tt) (Rep.η repr) (hlevel 0)
+  }
 ```
 
 This can be seen as a special case of the construction [above](#as-terminal-objects):

--- a/src/Cat/Functor/Properties/FullyFaithful.lagda.md
+++ b/src/Cat/Functor/Properties/FullyFaithful.lagda.md
@@ -3,6 +3,7 @@
 open import Cat.Diagram.Colimit.Coequaliser
 open import Cat.Diagram.Colimit.Coproduct
 open import Cat.Instances.Shape.Terminal
+open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Colimit.Initial
 open import Cat.Diagram.Limit.Equaliser
 open import Cat.Diagram.Limit.Terminal
@@ -167,8 +168,9 @@ ff→reflects-Terminal
   : (term : Terminal D)
   → ∀ {o} → term .Terminal.top D.≅ F.₀ o
   → Terminal C
+{-# INLINE ff→reflects-Terminal #-}
 ff→reflects-Terminal term is =
-  Limit→Terminal C (ff→reflects-Limit _ (Terminal→Limit D term) is)
+  Limit→Terminal C ¡F (ff→reflects-Limit _ (Terminal→Limit D (F F∘ ¡F) term) is)
 
 ff→reflects-Initial
   : (init : Initial D)

--- a/src/Cat/Functor/Properties/FullyFaithful.lagda.md
+++ b/src/Cat/Functor/Properties/FullyFaithful.lagda.md
@@ -3,9 +3,9 @@
 open import Cat.Diagram.Colimit.Coequaliser
 open import Cat.Diagram.Colimit.Coproduct
 open import Cat.Instances.Shape.Terminal
-open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Colimit.Initial
 open import Cat.Diagram.Limit.Equaliser
+open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Limit.Terminal
 open import Cat.Diagram.Limit.Product
 open import Cat.Diagram.Colimit.Base

--- a/src/Cat/Functor/Slice.lagda.md
+++ b/src/Cat/Functor/Slice.lagda.md
@@ -9,6 +9,7 @@ open import Cat.Instances.Slice
 open import Cat.Functor.Base
 open import Cat.Prelude
 
+import Cat.Functor.Reasoning
 import Cat.Reasoning
 ```
 -->
@@ -102,6 +103,7 @@ Sliced-lex {C = C} {D = D} {F = F} {X = X} flex = lex where
   module D = Cat.Reasoning D
   module Dx = Cat.Reasoning (Slice D (F .F₀ X))
   module C = Cat.Reasoning C
+  module F = Cat.Functor.Reasoning F
   open is-lex
   lex : is-lex (Sliced F X)
   lex .pres-pullback = pullback-above→pullback-below
@@ -119,11 +121,11 @@ $F(T)$, being isomorphic to the terminal object, is itself terminal!
 
 ```agda
   lex .pres-⊤ {T = T} term =
-    is-terminal-iso (Slice D (F .F₀ X))
+    is-terminal-iso
       (subst (Dx._≅ cut (F .F₁ (T .map))) (ap cut (F .F-id))
-        (F-map-iso (Sliced F X)
-          (⊤-unique (Slice C X) Slice-terminal-object (record { has⊤ = term }))))
-      Slice-terminal-object'
+       (F-map-iso (Sliced F X)
+         (⊤-unique Slice-terminal-object (record { top = T ; has-is-term = term }))))
+      Slice-is-terminal-object
 ```
 
 # Sliced adjoints

--- a/src/Cat/Instances/Assemblies/Limits.lagda.md
+++ b/src/Cat/Instances/Assemblies/Limits.lagda.md
@@ -163,8 +163,8 @@ tracked by the constant function with value $\sf{x}$.
 ```agda
 Assemblies-terminal : Terminal (Assemblies 𝔸 ℓ)
 Assemblies-terminal .top = ⊤Asm
-Assemblies-terminal .has⊤ X .centre  = !Asm
-Assemblies-terminal .has⊤ X .paths x = ext λ _ → refl
+Assemblies-terminal .has-is-term .is-terminal.! = !Asm
+Assemblies-terminal .has-is-term .is-terminal.!-unique _ = ext λ _ → refl
 ```
 -->
 

--- a/src/Cat/Instances/Coalgebras/Cartesian.lagda.md
+++ b/src/Cat/Instances/Coalgebras/Cartesian.lagda.md
@@ -405,9 +405,10 @@ the former is contractible if the latter is.
 ```agda
 Terminal-coalgebra : Terminal (Coalgebras W)
 Terminal-coalgebra .top = _
-Terminal-coalgebra .has⊤ (A , α) = Equiv→is-hlevel 0
-  (Equiv.inverse (_ , L-adjunct-is-equiv (Forget⊣Cofree W)))
-  (terminal .has⊤ A)
+Terminal-coalgebra .has-is-term =
+  hom-contr→is-terminal λ (A , α) →
+    Equiv→is-hlevel 0 (Equiv.inverse (_ , L-adjunct-is-equiv (Forget⊣Cofree W)))
+      (is-terminal→hom-contr (terminal .has-is-term) A)
 ```
 
 Since we have a terminal object and pullbacks, we have arbitrary finite

--- a/src/Cat/Instances/Graphs/Limits.lagda.md
+++ b/src/Cat/Instances/Graphs/Limits.lagda.md
@@ -113,9 +113,9 @@ Graphs-products a b .has-is-product .unique p q = ext record where
 
 Graphs-terminal : ∀ {o ℓ} → Terminal (Graphs o ℓ)
 Graphs-terminal .Terminal.top = ⊤ᴳ
-Graphs-terminal .Terminal.has⊤ x .centre .node = _
-Graphs-terminal .Terminal.has⊤ x .centre .edge = _
-Graphs-terminal .Terminal.has⊤ x .paths h = trivialᴳ!
+Graphs-terminal .Terminal.has-is-term .is-terminal.! .node _ = lift tt
+Graphs-terminal .Terminal.has-is-term .is-terminal.! .edge _ = lift tt
+Graphs-terminal .Terminal.has-is-term .is-terminal.!-unique h = trivialᴳ!
 
 Graphs-pullbacks : ∀ {o ℓ} → has-pullbacks (Graphs o ℓ)
 Graphs-pullbacks f g .apex = f ⊓ᴳ g

--- a/src/Cat/Instances/Presheaf/Colimits.lagda.md
+++ b/src/Cat/Instances/Presheaf/Colimits.lagda.md
@@ -55,12 +55,19 @@ private
 ⊥PSh .F-id = ext λ ()
 ⊥PSh .F-∘ _ _ = ext λ ()
 
+empty→is-initial-PSh
+  : ∀ (F : ⌞ PSh κ C ⌟)
+  → (∀ x → ¬ (F ʻ x))
+  → is-initial (PSh κ C) F
+{-# INLINE empty→is-initial-PSh #-}
+empty→is-initial-PSh F ¬Fx = record
+  { ¡ = NT (λ x Fx → absurd (¬Fx x Fx)) λ x y f → ext (λ Fx → absurd (¬Fx x Fx))
+  ; ¡-unique = λ h → ext (λ x Fx → absurd (¬Fx x Fx))
+  }
+
 PSh-initial : Initial (PSh κ C)
-PSh-initial = record { has⊥ = uniq } where
-  uniq : is-initial (PSh κ C) ⊥PSh
-  uniq x .centre .η _ ()
-  uniq x .centre .is-natural _ _ _ = ext λ ()
-  uniq x .paths f = ext λ _ ()
+PSh-initial .Initial.bot = ⊥PSh
+PSh-initial .Initial.has-is-init = empty→is-initial-PSh ⊥PSh λ _ ()
 
 _⊎PSh_ : (A B : PSh.Ob) → PSh.Ob
 (A ⊎PSh B) .F₀ i = el! (∣ A .F₀ i ∣ ⊎ ∣ B .F₀ i ∣)

--- a/src/Cat/Instances/Presheaf/Limits.lagda.md
+++ b/src/Cat/Instances/Presheaf/Limits.lagda.md
@@ -61,9 +61,11 @@ contr→is-terminal-PSh
   : ∀ (T : ⌞ PSh κ C ⌟)
   → ⦃ ∀ {c n} → H-Level ⌞ T .F₀ c ⌟ n ⦄
   → is-terminal (PSh κ C) T
-contr→is-terminal-PSh T _ .centre .η _ _ = hlevel!
-contr→is-terminal-PSh T _ .centre .is-natural _ _ _ = prop!
-contr→is-terminal-PSh T _ .paths _ = ext λ _ _ → prop!
+{-# INLINE contr→is-terminal-PSh #-}
+contr→is-terminal-PSh T = record
+  { ! = NT (λ _ _ → hlevel!) λ _ _ _ → prop!
+  ; !-unique = λ _ → ext λ _ _ → prop!
+  }
 
 prop→is-subterminal-PSh
   : ∀ (T : ⌞ PSh κ C ⌟)
@@ -72,7 +74,7 @@ prop→is-subterminal-PSh
 prop→is-subterminal-PSh T _ _ _ = ext λ _ _ → prop!
 
 PSh-terminal : Terminal (PSh κ C)
-PSh-terminal = record { has⊤ = contr→is-terminal-PSh ⊤PSh }
+PSh-terminal = record { has-is-term = contr→is-terminal-PSh ⊤PSh }
 ```
 
 The product presheaf is as described in the introduction, now with all

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -171,8 +171,8 @@ category of sets of _any_ level $\ell$ admits them.
 ```agda
   Sets-initial : Initial (Sets ℓ)
   Sets-initial .bot = el! (Lift _ ⊥)
-  Sets-initial .has⊥ _ .centre ()
-  Sets-initial .has⊥ _ .paths _ = ext λ ()
+  Sets-initial .has-is-init .is-initial.¡ = λ ()
+  Sets-initial .has-is-init .is-initial.¡-unique _ = ext λ ()
 ```
 
 Coproducts are given by disjoint sums:
@@ -287,11 +287,8 @@ disjoint images: We must project out a path $i = j$ from a path $\|
 truncation --- to prove $\bot$ using the assumption that $i ≠ j$.
 
 ```agda
-    coprod .different-images-are-disjoint i j i≠j os = contr map uniq where
-      map : Σ[ x ∈ F i ] Σ[ y ∈ F j ] (coprod.ι i x ≡ coprod.ι j y) → ∣ os ∣
-      map (i , j , p) = absurd (i≠j (ap (∥-∥₀-elim (λ _ → I .is-tr) fst) p))
-
-      uniq : ∀ x → map ≡ x
-      uniq _ = funext λ where
-        (_ , _ , p) → absurd (i≠j (ap (∥-∥₀-elim (λ _ → I .is-tr) fst) p))
+    coprod .different-images-are-disjoint i j i≠j .is-initial.¡ (_ , _ , p) =
+      absurd (i≠j (ap (∥-∥₀-elim (λ _ → I .is-tr) fst) p))
+    coprod .different-images-are-disjoint i j i≠j .is-initial.¡-unique _ = ext λ _ _ p →
+      absurd (i≠j (ap (∥-∥₀-elim (λ _ → I .is-tr) fst) p))
 ```

--- a/src/Cat/Instances/Sets/Complete.lagda.md
+++ b/src/Cat/Instances/Sets/Complete.lagda.md
@@ -103,7 +103,8 @@ category of sets of _any_ level $\ell$ admits them.
 ```agda
   Sets-terminal : Terminal (Sets ℓ)
   Sets-terminal .top = el! (Lift _ ⊤)
-  Sets-terminal .has⊤ _ = hlevel 0
+  Sets-terminal .has-is-term .is-terminal.! _ = lift tt
+  Sets-terminal .has-is-term .is-terminal.!-unique _ = prop!
 ```
 
 Products are given by product sets:

--- a/src/Cat/Instances/Sets/Counterexamples/SelfDual.lagda.md
+++ b/src/Cat/Instances/Sets/Counterexamples/SelfDual.lagda.md
@@ -49,7 +49,7 @@ open Sets.Inverses
 ```agda
 Sets^op-initial : Initial (Sets ℓ ^op)
 Sets^op-initial .bot = el! (Lift _ ⊤)
-Sets^op-initial .has⊥ x = hlevel 0
+Sets^op-initial .has-is-init = hom-contr→is-initial (λ _ → hlevel 0)
 ```
 <!--
 ```agda
@@ -89,7 +89,7 @@ $\Sets\op$ is univalent, so we invoke the propositionality of its initial object
 
 ```agda
     si≡⊤ : si .initial ≡ Sets^op-initial
-    si≡⊤ = ⊥-is-prop _ Sets^op-is-category _ _
+    si≡⊤ = ⊥-is-prop Sets^op-is-category _ _
 
     to-iso-⊤ : (A : Set ℓ) → (Lift ℓ ⊤ → ⌞ A ⌟) → A Sets^op.≅ el! (Lift ℓ ⊤)
     to-iso-⊤ A f = invertible→iso _ _ (subst (is-strict-initial (Sets ℓ ^op)) si≡⊤ (si .has-is-strict) A f)

--- a/src/Cat/Instances/Shape/Cospan.lagda.md
+++ b/src/Cat/Instances/Shape/Cospan.lagda.md
@@ -131,9 +131,10 @@ instance
 
 Terminal-·→·←· : ∀ {a b} → Terminal (·→·←· {a} {b})
 Terminal-·→·←· .Terminal.top = cs-c
-Terminal-·→·←· .Terminal.has⊤ cs-a = hlevel 0
-Terminal-·→·←· .Terminal.has⊤ cs-b = hlevel 0
-Terminal-·→·←· .Terminal.has⊤ cs-c = hlevel 0
+Terminal-·→·←· .Terminal.has-is-term = hom-contr→is-terminal λ where
+  cs-a → hlevel 0
+  cs-b → hlevel 0
+  cs-c → hlevel 0
 ```
 -->
 

--- a/src/Cat/Instances/Shape/Interval.lagda.md
+++ b/src/Cat/Instances/Shape/Interval.lagda.md
@@ -80,12 +80,7 @@ function.
 ```agda
 0≤1-top : Terminal 0≤1
 0≤1-top .top = true
-
-0≤1-top .has⊤ false .centre = _
-0≤1-top .has⊤ false .paths _ = refl
-
-0≤1-top .has⊤ true  .centre = _
-0≤1-top .has⊤ true  .paths _ = refl
+0≤1-top .has-is-term = hom-contr→is-terminal λ _ → hlevel 0
 
 0≤1-products : ∀ A B → Product 0≤1 A B
 0≤1-products A B .apex = and A B

--- a/src/Cat/Instances/Sheaf/Limits/Finite.lagda.md
+++ b/src/Cat/Instances/Sheaf/Limits/Finite.lagda.md
@@ -74,10 +74,12 @@ Sh[]-pullbacks {A = A} {B} {X} f g = pb where
 
   pb : Pullback (Sheaves J _) _ _
   pb .apex .fst = pb' .apex
-  pb .apex .snd = is-sheaf-limit {o' = lzero} {ℓ' = lzero} (Limit.has-limit (Pullback→Limit (PSh ℓ C) pb')) λ where
-    cs-a → A .snd
-    cs-b → B .snd
-    cs-c → X .snd
+  pb .apex .snd =
+    is-sheaf-limit {o' = lzero} {ℓ' = lzero}
+      (Limit.has-limit (Pullback→Limit (PSh ℓ C) (cospan→cospan-diagram lzero lzero f g) pb')) λ where
+        cs-a → A .snd
+        cs-b → B .snd
+        cs-c → X .snd
   pb .p₁ = pb' .p₁
   pb .p₂ = pb' .p₂
   pb .has-is-pb = record { Pullback pb' }
@@ -89,11 +91,11 @@ The terminal object in sheaves is even easier to define:
 ```agda
 Sh[]-terminal : Terminal (Sheaves J ℓ)
 Sh[]-terminal .top .fst = PSh-terminal _ C .top
-Sh[]-terminal .has⊤ (S , _) = PSh-terminal _ C .has⊤ S
-
 Sh[]-terminal .top .snd .whole _ _     = lift tt
 Sh[]-terminal .top .snd .glues _ _ _ _ = refl
 Sh[]-terminal .top .snd .separate _ _  = refl
+Sh[]-terminal .has-is-term = hom-contr→is-terminal λ S →
+  is-terminal→hom-contr (PSh-terminal ℓ C .has-is-term) (S .fst)
 ```
 
 <!--

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -262,15 +262,14 @@ module _ {o ℓ} {C : Precategory o ℓ} {c : ⌞ C ⌟} where
   open /-Hom
   open /-Obj
 
-  Slice-terminal-object' : is-terminal (Slice C c) (cut C.id)
-  Slice-terminal-object' obj .centre .map = obj .map
-  Slice-terminal-object' obj .centre .com = C.idl _
-  Slice-terminal-object' obj .paths other =
-    ext (sym (other .com) ∙ C.idl _)
+  Slice-is-terminal-object : is-terminal (Slice C c) (cut C.id)
+  Slice-is-terminal-object .is-terminal.! {obj} .map = obj .map
+  Slice-is-terminal-object .is-terminal.! {obj} .com = C.idl _
+  Slice-is-terminal-object .is-terminal.!-unique h = ext (sym (C.idl _) ∙ h .com)
 
   Slice-terminal-object : Terminal (Slice C c)
   Slice-terminal-object .Terminal.top  = _
-  Slice-terminal-object .Terminal.has⊤ = Slice-terminal-object'
+  Slice-terminal-object .Terminal.has-is-term = Slice-is-terminal-object
 ```
 
 <!--

--- a/src/Cat/Internal/Functor/Outer.lagda.md
+++ b/src/Cat/Internal/Functor/Outer.lagda.md
@@ -168,7 +168,7 @@ universal property of the pullback.
         coh =
           src ∘ (g ∘i homi (p₁ ∘ fₓ)) .ihom ≡⟨ (g ∘i homi (p₁ ∘ fₓ)) .has-src ⟩
           src ∘ p₁ ∘ fₓ ≡⟨ pulll square ⟩
-          (x ∘ p₂) ∘ fₓ ≡⟨ pullr (sym (!-unique _)) ⟩
+          (x ∘ p₂) ∘ fₓ ≡⟨ pullr (!-unique _) ⟩
           x ∘ ! ∎
 ```
 
@@ -187,7 +187,7 @@ of maps into a limit.
         tgt ∘ (g ∘i homi (p₁ ∘ fₓ)) .ihom ≡˘⟨ ap (tgt ∘_) p₁∘universal ⟩
         tgt ∘ p₁ ∘ universal _            ∎
     outf .P-id fₓ =
-      sym $ unique (sym (ap ihom (idli _))) (sym (!-unique _))
+      sym $ unique (sym (ap ihom (idli _))) (!-unique _)
     outf .P-∘ fₓ g h = unique
       (p₁∘universal
       ∙ ap ihom (sym $ associ _ _ _)
@@ -204,7 +204,7 @@ of maps into a limit.
             (sym (assoc _ _ _) ∙ ap (src ∘_) (sym (assoc _ _ _)))
             (sym (assoc _ _ _) ∙ ap (tgt ∘_) (sym (assoc _ _ _)))
             refl refl (sym (assoc _ _ _)))
-      (sym (!-unique _))
+      (!-unique _)
 ```
 </details>
 
@@ -233,7 +233,7 @@ covariant construction, performed above.
         coh =
           tgt ∘ (homi (p₁ ∘ fₓ) ∘i op-ihom g) .ihom ≡⟨ (homi (p₁ ∘ fₓ) ∘i op-ihom g) .has-tgt ⟩
           tgt ∘ p₁ ∘ fₓ ≡⟨ pulll square ⟩
-          (x ∘ p₂) ∘ fₓ ≡⟨ pullr (sym (!-unique _)) ⟩
+          (x ∘ p₂) ∘ fₓ ≡⟨ pullr (!-unique _) ⟩
           x ∘ ! ∎
     outf .P₁-tgt fₓ {y} g = src-coh where abstract
       src-coh : y ≡ src ∘ p₁ ∘ universal (hom-into-action.coh fₓ g)
@@ -242,7 +242,7 @@ covariant construction, performed above.
         ∙ (homi (p₁ ∘ fₓ) ∘i op-ihom g) .has-src)
     outf .P-id fₓ = sym $ unique
       (sym (ap ihom (ap₂ _∘i_ refl op-ihom-involutive ∙ idri _)))
-      (sym (!-unique _))
+      (!-unique _)
     outf .P-∘ fₓ g h = unique
       (p₁∘universal
         ∙ ap ihom (ap₂ _∘i_ refl op-ihom-involutive ∙ associ _ _ _)
@@ -262,7 +262,7 @@ covariant construction, performed above.
              (sym (assoc _ _ _) ∙ ap (src ∘_) (sym (assoc _ _ _)))
              (sym (assoc _ _ _) ∙ ap (tgt ∘_) (sym (assoc _ _ _)))
              (sym (assoc _ _ _)) refl)
-        (sym (!-unique _))
+        (!-unique _)
 ```
 </details>
 

--- a/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
@@ -138,7 +138,7 @@ answer is yes!
     → (f : Hom x y)
     → Monoid-hom (Mon→Hom-mon y mon) (Mon→Hom-mon x mon) (_∘ f)
   precompose-hom-mon-hom {mon = mon} f .pres-id =
-    (mon .η ∘ !) ∘ f ≡⟨ pullr (sym (!-unique (! ∘ f))) ⟩
+    (mon .η ∘ !) ∘ f ≡⟨ pullr (!-unique (! ∘ f)) ⟩
     mon .η ∘ !       ∎
   precompose-hom-mon-hom {mon = mon} f .pres-⋆ g h =
     (mon .μ ∘ ⟨ g , h ⟩) ∘ f   ≡⟨ pullr (⟨⟩∘ f) ⟩
@@ -276,9 +276,9 @@ functor is also [[fully faithful]].
     → C-Monoid-hom (α .η m · id) m-mon n-mon
   Nat→internal-mon-hom {m} {n} {m-mon} {n-mon} α .pres-η =
     (α .η m · id) ∘ (m-mon .η) ≡˘⟨ α .is-natural _ _ _ ·ₚ _ ⟩
-    α .η top · (id ∘ m-mon .η) ≡⟨ ap (α .η _ ·_) (id-comm-sym ∙ ap (m-mon .η ∘_) (sym (!-unique _))) ⟩
+    α .η top · (id ∘ m-mon .η) ≡⟨ ap (α .η _ ·_) (id-comm-sym ∙ ap (m-mon .η ∘_) (!-unique _)) ⟩
     α .η top · (m-mon .η ∘ !)  ≡⟨ α .η _ .snd .pres-id ⟩
-    n-mon .η ∘ !               ≡⟨ elimr (!-unique _) ⟩
+    n-mon .η ∘ !               ≡⟨ elimr (sym (!-unique _)) ⟩
     n-mon .η                   ∎
   Nat→internal-mon-hom {m} {n} {m-mon} {n-mon} α .pres-μ =
     α .η m · id ∘ (m-mon .μ)                               ≡˘⟨ α .is-natural _ _ _ ·ₚ _ ⟩

--- a/src/Cat/Monoidal/Instances/Cartesian.lagda.md
+++ b/src/Cat/Monoidal/Instances/Cartesian.lagda.md
@@ -60,7 +60,7 @@ formal proof requires a _lot_ of calculation, however:
     ni .eta x = ⟨ ! , id ⟩
     ni .inv x = π₂
     ni .eta∘inv x = ⟨⟩-unique₂
-      (pulll π₁∘⟨⟩ ∙ sym (!-unique _)) (cancell π₂∘⟨⟩) (!-unique₂ _ _) (idr _)
+      (pulll π₁∘⟨⟩ ∙ !-unique _) (cancell π₂∘⟨⟩) (!-unique₂ _ _) (idr _)
     ni .inv∘eta x = π₂∘⟨⟩
     ni .natural x y f = ⟨⟩-unique₂
       (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ cancelr π₂∘⟨⟩)
@@ -70,8 +70,8 @@ formal proof requires a _lot_ of calculation, however:
     ni .eta x = ⟨ id , ! ⟩
     ni .inv x = π₁
     ni .eta∘inv x = ⟨⟩-unique₂
-      (pulll π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ sym (!-unique _))
-      (idr _) (sym (!-unique _))
+      (pulll π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ !-unique _)
+      (idr _) (!-unique _)
     ni .inv∘eta x = π₁∘⟨⟩
     ni .natural x y f = ⟨⟩-unique₂
       (pulll π₁∘⟨⟩ ∙∙ pullr π₁∘⟨⟩ ∙∙ idr f)
@@ -112,7 +112,7 @@ We also have a system of [[diagonal morphisms|monoidal category with diagonals]]
   Cartesian-diagonal : Diagonals Cartesian-monoidal
   Cartesian-diagonal .diagonals ._=>_.η A = δ
   Cartesian-diagonal .diagonals ._=>_.is-natural x y f = products! products
-  Cartesian-diagonal .diagonal-λ→ = ap ⟨_, id ⟩ (sym (!-unique _))
+  Cartesian-diagonal .diagonal-λ→ = ap ⟨_, id ⟩ (!-unique _)
 ```
 
 <!--

--- a/src/Cat/Monoidal/Instances/Factorisations.lagda.md
+++ b/src/Cat/Monoidal/Instances/Factorisations.lagda.md
@@ -75,20 +75,20 @@ Ff-unit-is-initial : is-initial (Factorisations C) Ff-unit
 </summary>
 
 ```agda
-Ff-unit-is-initial other = record where
-  module o = Factorisation other
-  centre = record
-    { map = λ (X , Y , f) → record
-      { map = o.λ→ f
-      ; sq₀ = refl
-      ; sq₁ = sym (o.factors f) ∙ introl refl
-      }
-    ; com = λ x y f → Interpolant-pathp (other .S₁ f .sq₀)
+Ff-unit-is-initial .is-initial.¡ {other} = record
+  { map = λ (X , Y , f) → record
+    { map = o.λ→ f
+    ; sq₀ = refl
+    ; sq₁ = sym (o.factors f) ∙ introl refl
     }
-  paths h = ext λ x y f →
-    o.λ→ f          ≡⟨ h .sq₀ᶠᶠ f ⟩
-    h .mapᶠᶠ f ∘ id ≡⟨ elimr refl ⟩
-    h .mapᶠᶠ f      ∎
+  ; com = λ x y f → Interpolant-pathp (other .S₁ f .sq₀)
+  }
+  where module o = Factorisation other
+Ff-unit-is-initial .is-initial.¡-unique {other} h = ext λ x y f →
+    h .mapᶠᶠ f      ≡⟨ intror refl ⟩
+    h .mapᶠᶠ f ∘ id ≡˘⟨ h .sq₀ᶠᶠ f ⟩
+    o.λ→ f          ∎
+  where module o = Factorisation other
 ```
 
 </details>

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -290,22 +290,23 @@ in the relevant comma categories.
 ```agda
   go : Image C f
   go .bot = obj
-  go .has⊥ other = contr dh unique where
-    module o = ↓Obj other
+  go .has-is-init = hom-contr→is-initial λ o → contr (dh o) (unique o) where
+    module _ (other : ↓Obj (!Const (cut f)) (Forget-full-subcat {P = is-monic ⊙ map})) where
+      module o = ↓Obj other
 
-    the-lifting =
-      str-epi .snd _ (o.cod .snd) (o.map .map) right
-        (sym (o.map .com ∙ factors))
+      the-lifting =
+        str-epi .snd _ (o.cod .snd) (o.map .map) right
+          (sym (o.map .com ∙ factors))
 
-    dh : ↓Hom (!Const (cut f)) _ obj other
-    dh .top      = tt
-    dh .bot .map = the-lifting .centre .fst
-    dh .bot .com = the-lifting .centre .snd .snd
-    dh .com      = ext (idr _ ∙ sym (the-lifting .centre .snd .fst))
+      dh : ↓Hom (!Const (cut f)) _ obj other
+      dh .top      = tt
+      dh .bot .map = the-lifting .centre .fst
+      dh .bot .com = the-lifting .centre .snd .snd
+      dh .com      = ext (idr _ ∙ sym (the-lifting .centre .snd .fst))
 
-    unique : ∀ om → dh ≡ om
-    unique om = ↓Hom-path _ _ refl $ ext $ ap fst $ the-lifting .paths $
-      om .bot .map , sym (ap map (om .com)) ∙ idr _ , om .bot .com
+      unique : ∀ om → dh ≡ om
+      unique om = ↓Hom-path _ _ refl $ ext $ ap fst $ the-lifting .paths $
+        om .bot .map , sym (ap map (om .com)) ∙ idr _ , om .bot .com
 ```
 
 # In the lex case

--- a/src/Data/Bool/Order.lagda.md
+++ b/src/Data/Bool/Order.lagda.md
@@ -30,6 +30,13 @@ record _≤_ (x y : Bool) : Type where
 instance
   H-Level-≤ᵇ : ∀ {x y n} → H-Level (x ≤ y) (suc n)
   H-Level-≤ᵇ = prop-instance λ x y → refl
+  {-# OVERLAPPABLE H-Level-≤ᵇ #-}
+
+
+  H-Level-x≤true : ∀ {x} {n} → H-Level (x ≤ true) n
+  H-Level-x≤true {x = true} = basic-instance zero (contr (lift ttˢ) (λ _ → refl))
+  H-Level-x≤true {x = false} = basic-instance zero (contr (lift ttˢ) (λ _ → refl))
+
 ```
 -->
 

--- a/src/Homotopy/Space/Circle/Properties.lagda.md
+++ b/src/Homotopy/Space/Circle/Properties.lagda.md
@@ -9,6 +9,8 @@ open import Algebra.Group.Cat.Base
 open import Algebra.Group.Homotopy
 open import Algebra.Group
 
+open import Cat.Diagram.Terminal
+
 open import Data.Set.Truncation
 open import Data.Int.Universal
 open import Data.Bool
@@ -272,6 +274,6 @@ get that all of its higher homotopy groups are trivial.
 
 πₙ₊₂S¹≡0 : ∀ n → πₙ₊₁ (suc n) S¹∙ ≡ Zero-group {lzero}
 πₙ₊₂S¹≡0 n = ∫-Path
-  (Zero-group-is-terminal _ .centre)
+  (Zero-group-is-terminal .is-terminal.!)
   (is-contr→≃ (is-contr→∥-∥₀-is-contr (Ωⁿ⁺²S¹-is-contr n)) (hlevel 0) .snd)
 ```

--- a/src/Order/Diagram/Bottom.lagda.md
+++ b/src/Order/Diagram/Bottom.lagda.md
@@ -96,9 +96,12 @@ hom-sets with hom-props!
 
 ```agda
 is-bottom→initial : ∀ {x} → is-bottom x → is-initial (poset→category P) x
-is-bottom→initial is-bot x .centre = is-bot x
-is-bottom→initial is-bot x .paths _ = ≤-thin _ _
+{-# INLINE is-bottom→initial #-}
+is-bottom→initial x-bot = record
+  { ¡ = λ {x} → x-bot x
+  ; ¡-unique = λ {x} h → ≤-thin h (x-bot x)
+  }
 
 initial→is-bottom : ∀ {x} → is-initial (poset→category P) x → is-bottom x
-initial→is-bottom initial x = initial x .centre
+initial→is-bottom initial x = is-initial.¡ initial {x}
 ```

--- a/src/Order/Diagram/Top.lagda.md
+++ b/src/Order/Diagram/Top.lagda.md
@@ -95,9 +95,14 @@ hom-sets with hom-props!
 
 ```agda
 is-top→terminal : ∀ {x} → is-top x → is-terminal (poset→category P) x
-is-top→terminal is-top x .centre = is-top x
-is-top→terminal is-top x .paths _ = ≤-thin _ _
+{-# INLINE is-top→terminal #-}
+is-top→terminal is-top = record
+  { ! = λ {x} → is-top x
+  ; !-unique = λ {x} h → ≤-thin h (is-top x)
+  }
 
 terminal→is-top : ∀ {x} → is-terminal (poset→category P) x → is-top x
-terminal→is-top terminal x = terminal x .centre
+{-# INLINE terminal→is-top #-}
+terminal→is-top terminal x = is-terminal.! terminal
+-- terminal x .centre
 ```

--- a/src/Order/Instances/Coproduct.lagda.md
+++ b/src/Order/Instances/Coproduct.lagda.md
@@ -143,7 +143,7 @@ object]] in $\Pos$.
 ```agda
 Posets-initial : ∀ {o ℓ} → Initial (Posets o ℓ)
 Posets-initial .bot = 𝟘ᵖ
-Posets-initial .has⊥ P .centre .hom    ()
-Posets-initial .has⊥ P .centre .pres-≤ ()
-Posets-initial .has⊥ P .paths f = ext λ ()
+Posets-initial .has-is-init .is-initial.¡ .hom ()
+Posets-initial .has-is-init .is-initial.¡ .pres-≤ ()
+Posets-initial .has-is-init .is-initial.¡-unique _ = ext λ ()
 ```

--- a/src/Order/Instances/Product.lagda.md
+++ b/src/Order/Instances/Product.lagda.md
@@ -98,7 +98,7 @@ the set with one element is the [[terminal object]] in $\Pos$.
 ```agda
 Posets-terminal : ∀ {o ℓ} → Terminal (Posets o ℓ)
 Posets-terminal .top = 𝟙ᵖ
-Posets-terminal .has⊤ P .centre .hom    _ = lift tt
-Posets-terminal .has⊤ P .centre .pres-≤ _ = lift tt
-Posets-terminal .has⊤ P .paths f = ext λ _ → refl
+Posets-terminal .has-is-term .is-terminal.! .hom x = lift tt
+Posets-terminal .has-is-term .is-terminal.! .pres-≤ _ = lift tt
+Posets-terminal .has-is-term .is-terminal.!-unique h = ext λ _ → refl
 ```

--- a/src/Topoi/Base.lagda.md
+++ b/src/Topoi/Base.lagda.md
@@ -22,6 +22,7 @@ open import Cat.Instances.Elements
 open import Cat.Functor.Bifunctor
 open import Cat.Instances.Functor
 open import Cat.Diagram.Pullback
+open import Cat.Diagram.Terminal
 open import Cat.Functor.Pullback
 open import Cat.Functor.Adjoint
 open import Cat.Instances.Slice
@@ -322,11 +323,12 @@ limits directly for efficiency concerns. </summary>
 [adjoint equivalence]: Cat.Functor.Equivalence.html
 
 ```agda
-  sets .L-lex .pres-⊤ {T} psh-terminal set = contr (cent .η _) uniq where
-    func = incl .F₀ set
-    cent = psh-terminal func .centre
-    uniq : ∀ f → cent .η _ ≡ f
-    uniq f = psh-terminal func .paths f' ηₚ _ where
+  sets .L-lex .pres-⊤ {T} psh-terminal = term' where
+    open is-terminal
+
+    term' : is-terminal (Sets κ) _
+    term' .! {X} = psh-terminal .! {incl .F₀ X} .η _
+    term' .!-unique f = psh-terminal .!-unique f' ηₚ _ where
       f' : _ => _
       f' .η _ = f
       f' .is-natural _ _ _ = funext λ x → happly (sym (T .F-id)) _
@@ -677,7 +679,7 @@ The composition of two left-exact functors is again left-exact, so
 there's no impediment to composition there, either.
 
 ```agda
-  mk .Inv-lex .pres-⊤ term ob = g.Inv-lex .pres-⊤ (f.Inv-lex .pres-⊤ term) _
+  mk .Inv-lex .pres-⊤ term = g.Inv-lex .pres-⊤ (f.Inv-lex .pres-⊤ term)
   mk .Inv-lex .pres-pullback pb = g.Inv-lex .pres-pullback (f.Inv-lex .pres-pullback pb)
 ```
 

--- a/src/Topoi/Reasoning.lagda.md
+++ b/src/Topoi/Reasoning.lagda.md
@@ -87,7 +87,7 @@ do it by hand for the [[terminal object]], binary [[products]], and binary
   open Terminal
   terminal-sheaf : Terminal 𝒯
   terminal-sheaf .top = L.₀ (PSh-terminal _ site .top)
-  terminal-sheaf .has⊤ = L-lex.pres-⊤ (PSh-terminal _ site .has⊤)
+  terminal-sheaf .has-is-term = L-lex.pres-⊤ (PSh-terminal _ site .has-is-term)
 
   product-sheaf : ∀ A B → Product 𝒯 A B
   product-sheaf A B = product' where
@@ -103,7 +103,7 @@ do it by hand for the [[terminal object]], binary [[products]], and binary
       let
         prod =
           L-lex.pres-product
-            (PSh-terminal _ site .has⊤)
+            (PSh-terminal _ site .has-is-term)
             (product-presheaf .has-is-product)
       in is-product-iso (Lι-iso _) (Lι-iso _) prod
 


### PR DESCRIPTION
# Description

Previously, we defined initial and terminal objects directly via contractibility. This led to some really baroque goals, as things like `term.!` unfolded to `term _ . centre`. This PR defines `is-initial` and `is-terminal` records, and ports over all code to use the new records. I've also take the opportunity to sprinkle around some `INLINE` pragrams on helper functions that create initial/terminal objects.

On a whole, the code looks a lot clearer, though there are some places where things get a bit uglier.
